### PR TITLE
More fixes to crypto internals

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/CachedLruExchangeDataManager.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/CachedLruExchangeDataManager.kt
@@ -145,7 +145,7 @@ private class CachedLruExchangeDataManagerInGroup(
 		// Check no one has evicted this entry before the cache additional info method has been called, else don't cache
 		// additional info
 		if (exchangeDataByIdCache.get(toCache.exchangeData.id) != null) {
-			exchangeDataByIdCache.set(toCache.exchangeData.id, CompletableDeferred(toCache)) // No need to check data since we
+			exchangeDataByIdCache.set(toCache.exchangeData.id, CompletableDeferred(toCache)) // No need to check cache size since we are only updating an existing key
 			if (toCache.decryptedDetails?.verified == true && delegateToVerifiedExchangeDataId[toCache.exchangeData.delegate]?.isCompleted != true) {
 				delegateToVerifiedExchangeDataId[toCache.exchangeData.delegate] = CompletableDeferred(toCache.exchangeData.id)
 			}

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/JsonEncryptionServiceImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/JsonEncryptionServiceImpl.kt
@@ -122,15 +122,41 @@ class JsonEncryptionServiceImpl(
 	override fun requiresEncryption(plainJson: JsonObject, manifest: EncryptedFieldsManifest): Boolean =
 		manifest.topLevelFields.any {
 			plainJson.containsKey(it)
-		} || manifest.nestedObjectsKeys.any { (nestedObjectField, manifest) ->
-			plainJson[nestedObjectField]?.let { requiresEncryption(it.jsonObject, manifest) } == true
-		} || manifest.arraysValuesKeys.any { (arrayField, manifest) ->
-			plainJson[arrayField]?.jsonArray?.any { arrayElement ->
-				requiresEncryption(arrayElement.jsonObject, manifest)
+		} || manifest.nestedObjectsKeys.any { (nestedObjectField, subManifest) ->
+			plainJson[nestedObjectField]?.let { value ->
+				when (value) {
+					JsonNull -> false
+					is JsonObject -> requiresEncryption(value, subManifest)
+					else -> throw IllegalArgumentException("${manifest.path}$nestedObjectField should be an object or null")
+				}
 			} == true
-		} || manifest.mapsValuesKeys.any { (mapField, manifest) ->
-			plainJson[mapField]?.jsonObject?.values?.any { mapElement ->
-				requiresEncryption(mapElement.jsonObject, manifest)
+		} || manifest.arraysValuesKeys.any { (arrayField, subManifest) ->
+			plainJson[arrayField]?.let { value ->
+				when (value) {
+					JsonNull -> false
+					is JsonArray -> value.any { arrayElement ->
+						when (arrayElement) {
+							JsonNull -> false
+							is JsonObject -> requiresEncryption(arrayElement, subManifest)
+							else -> throw IllegalArgumentException("All items of ${manifest.path}$arrayField should be objects or null")
+						}
+					}
+					else -> throw IllegalArgumentException("${manifest.path}$arrayField should be an array or null")
+				}
+			} == true
+		} || manifest.mapsValuesKeys.any { (mapField, subManifest) ->
+			plainJson[mapField]?.let { value ->
+				when (value) {
+					JsonNull -> false
+					is JsonObject -> value.values.any { mapElement ->
+						when (mapElement) {
+							JsonNull -> false
+							is JsonObject -> requiresEncryption(mapElement, subManifest)
+							else -> throw IllegalArgumentException("All values in map-like object ${manifest.path}$mapField should be objects or null")
+						}
+					}
+					else -> throw IllegalArgumentException("${manifest.path}$mapField should be an object or null")
+				}
 			} == true
 		}
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/RecoveryDataEncryptionImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/RecoveryDataEncryptionImpl.kt
@@ -16,6 +16,7 @@ import com.icure.cardinal.sdk.utils.LongPollingUtils
 import com.icure.cardinal.sdk.utils.base64Encode
 import com.icure.cardinal.sdk.utils.currentEpochMs
 import com.icure.cardinal.sdk.utils.decode
+import com.icure.cardinal.sdk.utils.getLogger
 import com.icure.kryptom.crypto.AesAlgorithm
 import com.icure.kryptom.crypto.AesService
 import com.icure.kryptom.crypto.CryptoService
@@ -23,6 +24,7 @@ import com.icure.kryptom.crypto.RsaAlgorithm
 import com.icure.kryptom.crypto.RsaKeypair
 import com.icure.kryptom.utils.toHexString
 import com.icure.utils.InternalIcureApi
+import io.ktor.utils.io.CancellationException
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.SerialName
@@ -56,12 +58,15 @@ private data class DelegateKeyPairInfo(
 	}
 }
 
+private val log = getLogger("RecoveryDataEncryption")
+
 @OptIn(InternalIcureApi::class)
 class RecoveryDataEncryptionImpl(
 	private val primitives: CryptoService,
 	defaultRawApiConfig: RawApiConfig,
 	createRawApi: (RawApiConfig) -> RawRecoveryDataApi
 ) : RecoveryDataEncryption {
+
 	override val raw = createRawApi(defaultRawApiConfig)
 	private val rawForLongPolling = if (defaultRawApiConfig.requestTimeout?.let { it.inWholeSeconds >= MAX_WAIT_DURATION_S + REQUEST_TIMEOUT_MARGIN_S } != false) {
 		raw
@@ -130,7 +135,11 @@ class RecoveryDataEncryptionImpl(
 			}.toMap()
 		}
 	}.also {
-		if (autoDelete && it.isSuccess) raw.deleteRecoveryData(recoveryKeyToId(recoveryKey))
+		if (autoDelete && it.isSuccess) kotlin.runCatching {
+			raw.deleteRecoveryData(recoveryKeyToId(recoveryKey))
+		}.onFailure { e ->
+			if (e !is CancellationException) log.w { "Failed to auto-delete recovery data after successful recovery, id=${recoveryKeyToId(recoveryKey)}" }
+		}
 	}
 
 	override suspend fun createAndSaveExchangeDataRecoveryData(
@@ -181,7 +190,7 @@ class RecoveryDataEncryptionImpl(
 				content.toString().toByteArray(Charsets.UTF_8),
 				recoveryKeyAes
 			).base64Encode()
-		val expirationInstant = lifetimeSeconds?.let { currentEpochMs() + it * 1000 }
+		val expirationInstant = lifetimeSeconds?.let { currentEpochMs() + it * 1000L }
 		val data = RecoveryData(
 			id = id,
 			encryptedSelf = encryptedSelf,
@@ -220,6 +229,9 @@ class RecoveryDataEncryptionImpl(
 				if (it.type != expectedType) {
 					RecoveryResult.Failure(RecoveryDataUseFailureReason.InvalidType)
 				} else {
+					// Can fail with exception isntead of "RecoveryResult.Failure" if the recovery key does not match
+					// what was used to encrypt the content but is accceptable since the recovery data id is obtained
+					// from the encryption key that should have been used
 					val decrypted =
 						primitives.aes.decrypt(it.encryptedSelf.decode(), recoveryKey.loadAesKey(primitives))
 					val decryptedUtf8 = decrypted.decodeToString()

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/SecureDelegationsManagerImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/SecureDelegationsManagerImpl.kt
@@ -282,9 +282,9 @@ class SecureDelegationsManagerImpl (
 		} else {
 			makeExchangeDataIdInfoForDelegate(entityGroupId, delegatorReference, delegate, exchangeDataInfo)
 		}
-		val encryptedSecretIds = secureDelegationsEncryption.encryptSecretIds(shareSecretIds.toSet(), exchangeDataInfo.unencryptedContent.exchangeKey)
-		val encryptedEncryptionKeys = secureDelegationsEncryption.encryptEncryptionKeys(shareEncryptionKeys.toSet(), exchangeDataInfo.unencryptedContent.exchangeKey)
-		val encryptedOwningEntityIds = secureDelegationsEncryption.encryptOwningEntityIds(shareOwningEntityIds.toSet(), exchangeDataInfo.unencryptedContent.exchangeKey)
+		val encryptedSecretIds = secureDelegationsEncryption.encryptSecretIds(shareSecretIds, exchangeDataInfo.unencryptedContent.exchangeKey)
+		val encryptedEncryptionKeys = secureDelegationsEncryption.encryptEncryptionKeys(shareEncryptionKeys, exchangeDataInfo.unencryptedContent.exchangeKey)
+		val encryptedOwningEntityIds = secureDelegationsEncryption.encryptOwningEntityIds(shareOwningEntityIds, exchangeDataInfo.unencryptedContent.exchangeKey)
 		return EncryptedExchangeDataInfo(
 			secretIds = encryptedSecretIds,
 			encryptionKeys = encryptedEncryptionKeys,
@@ -316,19 +316,28 @@ class SecureDelegationsManagerImpl (
 		verifiedExchangeData: ExchangeDataWithUnencryptedContent
 	): EncryptedExchangeDataIdInfo {
 		val delegatorActorIsAnonymous = userKeys.delegatorActorIsAnonymous()
+		// TODO parallel requests sharing for the same delegate could trigger parallel requests to the api, minor performance concern, not a correctness issue
 		val (delegateIsAnonymous, verifiedDelegateKeys) = dataOwnerAnonymityCache.get(delegateReference) ?: dataOwnerApi.getCryptoActorStubInGroup(delegateReference).let { delegate ->
 			val delegateIsAnonymous = cryptoStrategies.dataOwnerRequiresAnonymousDelegation(
 				dataOwner = delegate,
 				groupId = delegateReference.normalized(boundGroup).groupId
 			)
-			if (delegatorActorIsAnonymous && !delegateIsAnonymous) {
-				// Important: this requires that the exchange data signature also validates the authenticity of the public keys included in there.
-				val allDelegateKeys = cryptoService.loadEncryptionKeysForDataOwner(delegate.stub)
-				val verifiedExchangeDataFingerprints = verifiedExchangeData.exchangeData.exchangeKey.keys
-				val verifiedDelegateKeys = allDelegateKeys.filter { it.pubSpkiHexString.fingerprintV2() in verifiedExchangeDataFingerprints }
-				Pair(delegateIsAnonymous, verifiedDelegateKeys).also { dataOwnerAnonymityCache.set(delegateReference, it) }
-			} else Pair(delegateIsAnonymous, null)
+			(
+				if (delegatorActorIsAnonymous && !delegateIsAnonymous) {
+					// Important: this requires that the exchange data signature also validates the authenticity of the public keys included in there.
+					val allDelegateKeys = cryptoService.loadEncryptionKeysForDataOwner(delegate.stub)
+					val verifiedExchangeDataFingerprints = verifiedExchangeData.exchangeData.exchangeKey.keys
+					val verifiedDelegateKeys = allDelegateKeys.filter { it.pubSpkiHexString.fingerprintV2() in verifiedExchangeDataFingerprints }
+					Pair(delegateIsAnonymous, verifiedDelegateKeys)
+				} else {
+					// If both are explicit, both are implicit, or delegator is explicit and delegate is anonymous, we
+					// don't need to use the delegate keys to create the exchange data info for the secure delegation,
+					// can leave null
+					Pair(delegateIsAnonymous, null)
+				}
+			).also { dataOwnerAnonymityCache.set(delegateReference, it) }
 		}
+
 		return when {
 			!delegateIsAnonymous && !delegatorActorIsAnonymous ->
 				EncryptedExchangeDataIdInfo(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/UserEncryptionKeysManagerImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/UserEncryptionKeysManagerImpl.kt
@@ -294,7 +294,7 @@ private class KeyLoader(
 				DataOwnerKeyInfo.Found(
 					it.pubSpkiHexString,
 					it.key,
-					isVerified = combinedVerificationDetails.getValue(dataOwnerInfo.dataOwner.id)[it.pubSpkiHexString.fingerprintV1()] == true,
+					isVerified = combinedVerificationDetails[dataOwnerInfo.dataOwner.id]?.get(it.pubSpkiHexString.fingerprintV1()) == true,
 					isDevice = false
 				)
 			}


### PR DESCRIPTION
Continuation of bfa9f8e9ebbd5a38b4816ca1dba246ae516d5bc2

Fixes include:
- Fixes to caching of cryptography info (there were bugs where the cache was never properly populated / lookedup / cleaned)
- Prompt cancellation on decryption: 
  - some methods were potentially swallowing CancellationExceptions, which would cause cancellation to be ignored until the next suspension point
  - Added `ensureActive` in some methods to have prompt cancellation even when cryptographic methods are not actually suspending (all platforms except js)
- Improved error flows with clearer messages