### PR TITLE
build: allow overriding artifactId via Gradle property

### DIFF
--- a/cardinal-sdk/build.gradle.kts
+++ b/cardinal-sdk/build.gradle.kts
@@ -178,7 +178,8 @@ fun projectHasSignatureProperties() =
 //}
 
 mavenPublishing {
-	coordinates(group as String, project.name, project.version as String)
+	val publishedArtifactId: String = (findProperty("artifactId") as String?)?.takeIf { it.isNotBlank() } ?: project.name
+	coordinates(group as String, publishedArtifactId, project.version as String)
 
 	pom {
 		name.set("CardinalSDK")


### PR DESCRIPTION
## Summary
- `mavenPublishing.coordinates(...)` now reads an optional `artifactId` Gradle property and falls back to `project.name` when unset.
- Unblocks the deprecated/legacy-support publish workflow in `the-forge` to publish this module under a distinct artifactId (e.g. `cardinal-sdk-legacy-support`) without colliding with the regular `cardinal-sdk` release.

## Test plan
- [ ] Regular publish runs unchanged: no `artifactId` property → coordinates resolve to `com.icure:cardinal-sdk:<version>`.
- [ ] Legacy publish run with `-PartifactId=cardinal-sdk-legacy-support` (or `ORG_GRADLE_PROJECT_artifactId`) produces `com.icure:cardinal-sdk-legacy-support:<version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)