### PR TITLE
Reviewed SortableFilterOptions

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ContactFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ContactFilters.kt
@@ -278,31 +278,24 @@ object ContactFilters {
 	 * have at least an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the contacts will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
-	 *
 	 * @param identifiers a list of identifiers
 	 */
 	fun byIdentifiersForSelf(
 		identifiers: List<Identifier>
-	): SortableFilterOptions<Contact> = ByIdentifiersForSelf(identifiers)
+	): FilterOptions<Contact> = ByIdentifiersForSelf(identifiers)
 
 	/**
 	 * Options for contact filtering which match all the contacts shared directly (i.e. ignoring hierarchies) with a specific data owner
 	 * that have at least an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the contacts will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
 	 * @param dataOwnerId a data owner id
 	 * @param identifiers a list of identifiers
 	 */
 	fun byIdentifiersForDataOwner(
 		dataOwnerId: String,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<Contact> = ByIdentifiersForDataOwner(
+	): BaseFilterOptions<Contact> = ByIdentifiersForDataOwner(
 		identifiers = identifiers,
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null)
 	)
@@ -313,7 +306,7 @@ object ContactFilters {
 	fun byIdentifiersForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<Contact> = ByIdentifiersForDataOwner(
+	): BaseFilterOptions<Contact> = ByIdentifiersForDataOwner(
 		identifiers = identifiers,
 		dataOwnerId = dataOwner
 	)
@@ -731,15 +724,12 @@ object ContactFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the contacts will be sorted by the patients, using
-	 * the same order as the input patients.
-	 *
 	 * @param patients a list of patients.
 	 */
 	@OptIn(InternalIcureApi::class)
 	fun byPatientsForSelf(
 		patients: List<Patient>
-	): SortableFilterOptions<Contact> = ByPatientsForSelf(
+	): FilterOptions<Contact> = ByPatientsForSelf(
 		patients = patients.map { it.toEncryptionMetadataStub() }
 	)
 
@@ -774,17 +764,12 @@ object ContactFilters {
 	/**
 	 * Options for contact filtering which match all contacts shared directly (i.e. ignoring hierarchies) with the current data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the contacts will be sorted by the linked patients
-	 * secret id, using the same order as the input.
 	 *
 	 * @param secretIds a list of patients secret ids
 	 */
 	fun byPatientsSecretIdsForSelf(
 		secretIds: List<String>
-	): SortableFilterOptions<Contact> = ByPatientsSecretIdsForSelf(
-		secretIds = secretIds,
-	)
-
+	): FilterOptions<Contact> = ByPatientsSecretIdsForSelf(secretIds = secretIds)
 
 	/**
 	 * Options for contact filtering which match all contacts that have at least a service with an id in [serviceIds].
@@ -858,12 +843,12 @@ object ContactFilters {
 	internal class ByIdentifiersForDataOwner(
 		val identifiers: List<Identifier>,
 		val dataOwnerId: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Contact>
+	) : BaseFilterOptions<Contact>
 
 	@Serializable
 	internal class ByIdentifiersForSelf(
 		val identifiers: List<Identifier>
-	) : SortableFilterOptions<Contact>
+	) : FilterOptions<Contact>
 
 	@Serializable
 	internal class ByCodeAndOpeningDateForDataOwner(
@@ -975,7 +960,7 @@ object ContactFilters {
 	@InternalIcureApi
 	internal class ByPatientsForSelf(
 		val patients: List<EntityWithEncryptionMetadataStub>,
-	): SortableFilterOptions<Contact>
+	): FilterOptions<Contact>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForDataOwner(
@@ -986,7 +971,7 @@ object ContactFilters {
 	@Serializable
 	internal class ByPatientsSecretIdsForSelf(
 		val secretIds: List<String>,
-	): SortableFilterOptions<Contact>
+	): FilterOptions<Contact>
 
 	@Serializable
 	internal class ByServiceIds(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ContactFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ContactFilters.kt
@@ -686,9 +686,6 @@ object ContactFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the contacts will be sorted by the patients, using
-	 * the same order as the input patients.
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param patients a list of patients.
 	 */
@@ -696,7 +693,7 @@ object ContactFilters {
 	fun byPatientsForDataOwner(
 		dataOwnerId: String,
 		patients: List<Patient>
-	): SortableFilterOptions<Contact> = ByPatientsForDataOwner(
+	): FilterOptions<Contact> = ByPatientsForDataOwner(
 		patients = patients.map { Pair(it.toEncryptionMetadataStub(), null) },
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null),
 	)
@@ -708,7 +705,7 @@ object ContactFilters {
 	fun byPatientsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		patients: List<GroupScoped<Patient>>
-	): SortableFilterOptions<Contact> = ByPatientsForDataOwner(
+	): FilterOptions<Contact> = ByPatientsForDataOwner(
 		patients = patients.map { Pair(it.entity.toEncryptionMetadataStub(), it.groupId) },
 		dataOwnerId = dataOwner
 	)
@@ -736,8 +733,6 @@ object ContactFilters {
 	/**
 	 * Options for contact filtering which match all contacts shared directly (i.e. ignoring hierarchies) with a specific data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the contacts will be sorted by the linked patients
-	 * secret id, using the same order as the input.
 	 *
 	 * @param dataOwnerId a data owner id
 	 * @param secretIds a list of patients secret ids
@@ -745,7 +740,7 @@ object ContactFilters {
 	fun byPatientsSecretIdsForDataOwner(
 		dataOwnerId: String,
 		secretIds: List<String>
-	): BaseSortableFilterOptions<Contact> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<Contact> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null),
 	)
@@ -756,7 +751,7 @@ object ContactFilters {
 	fun byPatientsSecretIdsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		secretIds: List<String>
-	): BaseSortableFilterOptions<Contact> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<Contact> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = dataOwner
 	)
@@ -954,7 +949,7 @@ object ContactFilters {
 	internal class ByPatientsForDataOwner(
 		val patients: List<Pair<EntityWithEncryptionMetadataStub, String?>>,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Contact>
+	): BaseFilterOptions<Contact>
 
 	@Serializable
 	@InternalIcureApi
@@ -966,7 +961,7 @@ object ContactFilters {
 	internal class ByPatientsSecretIdsForDataOwner(
 		val secretIds: List<String>,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Contact>
+	): BaseFilterOptions<Contact>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForSelf(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/DocumentFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/DocumentFilters.kt
@@ -499,8 +499,6 @@ object DocumentFilters {
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with a specific data owner that have a certain code.
 	 * If you specify only the [codeType] you will get all entities that have at least a code of that type.
 	 *
-	 * These options are sortable. When sorting using these options the documents will be sorted by [codeCode].
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
@@ -511,7 +509,7 @@ object DocumentFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): BaseSortableFilterOptions<Document> = ByCodeForDataOwner(
+	): BaseFilterOptions<Document> = ByCodeForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
@@ -525,7 +523,7 @@ object DocumentFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): BaseSortableFilterOptions<Document> = ByCodeForDataOwner(
+	): BaseFilterOptions<Document> = ByCodeForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		dataOwnerId = dataOwner
@@ -554,8 +552,6 @@ object DocumentFilters {
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with a specific data owner that have a certain tag.
 	 * If you specify only the [tagType] you will get all entities that have at least a tag of that type.
 	 *
-	 * These options are sortable. When sorting using these options the documents will be sorted by [tagCode].
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
@@ -566,7 +562,7 @@ object DocumentFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): BaseSortableFilterOptions<Document> = ByTagForDataOwner(
+	): BaseFilterOptions<Document> = ByTagForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
@@ -580,7 +576,7 @@ object DocumentFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): BaseSortableFilterOptions<Document> = ByTagForDataOwner(
+	): BaseFilterOptions<Document> = ByTagForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		dataOwnerId = dataOwner
@@ -590,8 +586,6 @@ object DocumentFilters {
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with the current data owner that have a certain tag.
 	 * If you specify only the [tagType] you will get all entities that have at least a tag of that type.
 	 *
-	 * These options are sortable. When sorting using these options the documents will be sorted by [tagCode].
-	 *
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
 	 * with a tag of the provided type.
@@ -600,7 +594,7 @@ object DocumentFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): SortableFilterOptions<Document> = ByTagForSelf(
+	): FilterOptions<Document> = ByTagForSelf(
 		tagType = tagType,
 		tagCode = tagCode
 	)
@@ -709,7 +703,7 @@ object DocumentFilters {
 		val codeType: String,
 		val codeCode: String?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Document>
+	): BaseFilterOptions<Document>
 
 	@Serializable
 	internal class ByCodeForSelf(
@@ -722,13 +716,13 @@ object DocumentFilters {
 		val tagType: String,
 		val tagCode: String?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Document>
+	): BaseFilterOptions<Document>
 
 	@Serializable
 	internal class ByTagForSelf(
 		val tagType: String,
 		val tagCode: String?,
-	): SortableFilterOptions<Document>
+	): FilterOptions<Document>
 }
 
 @InternalIcureApi

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/HealthElementFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/HealthElementFilters.kt
@@ -57,10 +57,6 @@ object HealthElementFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
-	 *
 	 * @param dataOwnerId a data owner id or null to use the current data owner id
 	 * @param identifiers a list of identifiers
 	 * @return options for health element filtering
@@ -68,7 +64,7 @@ object HealthElementFilters {
 	fun byIdentifiersForDataOwner(
 		dataOwnerId: String,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<HealthElement> =
+	): BaseFilterOptions<HealthElement> =
 		ByIdentifiersForDataOwner(identifiers, EntityReferenceInGroup(entityId = dataOwnerId, groupId = null))
 
 	/**
@@ -77,7 +73,7 @@ object HealthElementFilters {
 	fun byIdentifiersForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<HealthElement> =
+	): BaseFilterOptions<HealthElement> =
 		ByIdentifiersForDataOwner(identifiers, dataOwner)
 
 	/**
@@ -96,8 +92,6 @@ object HealthElementFilters {
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with a specific data owner that have a certain code.
 	 * If you specify only the [codeType] you will get all entities that have at least a code of that type.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by [codeCode].
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
@@ -108,7 +102,7 @@ object HealthElementFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): BaseSortableFilterOptions<HealthElement> = ByCodeForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByCodeForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
@@ -122,7 +116,7 @@ object HealthElementFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): BaseSortableFilterOptions<HealthElement> = ByCodeForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByCodeForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		dataOwnerId = dataOwner
@@ -149,8 +143,6 @@ object HealthElementFilters {
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with a specific data owner that have a certain tag.
 	 * If you specify only the [tagType] you will get all entities that have at least a tag of that type.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by [tagCode].
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
@@ -161,7 +153,7 @@ object HealthElementFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): BaseSortableFilterOptions<HealthElement> = ByTagForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByTagForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
@@ -175,7 +167,7 @@ object HealthElementFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): BaseSortableFilterOptions<HealthElement> = ByTagForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByTagForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		dataOwnerId = dataOwner
@@ -209,9 +201,6 @@ object HealthElementFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by the patients, using
-	 * the same order as the input patients.
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param patients a list of patients.
 	 */
@@ -219,7 +208,7 @@ object HealthElementFilters {
 	fun byPatientsForDataOwner(
 		dataOwnerId: String,
 		patients: List<Patient>
-	): SortableFilterOptions<HealthElement> = ByPatientsForDataOwner(
+	): FilterOptions<HealthElement> = ByPatientsForDataOwner(
 		patients = patients.map { Pair(it.toEncryptionMetadataStub(), null) },
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
 	)
@@ -231,7 +220,7 @@ object HealthElementFilters {
 	fun byPatientsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		patients: List<GroupScoped<Patient>>
-	): SortableFilterOptions<HealthElement> = ByPatientsForDataOwner(
+	): FilterOptions<HealthElement> = ByPatientsForDataOwner(
 		patients = patients.map { Pair(it.entity.toEncryptionMetadataStub(), it.groupId) },
 		dataOwnerId = dataOwner
 	)
@@ -259,8 +248,6 @@ object HealthElementFilters {
 	/**
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with a specific data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the health elements will be sorted by the linked patients
-	 * secret id, using the same order as the input.
 	 *
 	 * @param dataOwnerId a data owner id
 	 * @param secretIds a list of patients secret ids
@@ -268,7 +255,7 @@ object HealthElementFilters {
 	fun byPatientsSecretIdsForDataOwner(
 		dataOwnerId: String,
 		secretIds: List<String>
-	): BaseSortableFilterOptions<HealthElement> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
 	)
@@ -279,7 +266,7 @@ object HealthElementFilters {
 	fun byPatientsSecretIdsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		secretIds: List<String>
-	): BaseSortableFilterOptions<HealthElement> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<HealthElement> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = dataOwner
 	)
@@ -501,7 +488,7 @@ object HealthElementFilters {
 	internal class ByIdentifiersForDataOwner(
 		val identifiers: List<Identifier>,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<HealthElement>
+	): BaseFilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByIdentifiersForSelf(
@@ -513,7 +500,7 @@ object HealthElementFilters {
 		val codeType: String,
 		val codeCode: String?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<HealthElement>
+	): BaseFilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByCodeForSelf(
@@ -526,7 +513,7 @@ object HealthElementFilters {
 		val tagType: String,
 		val tagCode: String?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<HealthElement>
+	): BaseFilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByTagForSelf(
@@ -539,7 +526,7 @@ object HealthElementFilters {
 	internal class ByPatientsForDataOwner(
 		val patients: List<Pair<EntityWithEncryptionMetadataStub, String?>>,
 		val dataOwnerId: EntityReferenceInGroup
-	) : SortableFilterOptions<HealthElement>
+	) : FilterOptions<HealthElement>
 
 	@Serializable
 	@InternalIcureApi
@@ -551,7 +538,7 @@ object HealthElementFilters {
 	internal class ByPatientsSecretIdsForDataOwner(
 		val secretIds: List<String>,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<HealthElement>
+	): BaseFilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForSelf(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/HealthElementFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/HealthElementFilters.kt
@@ -85,17 +85,12 @@ object HealthElementFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
-	 *
 	 * @param identifiers a list of identifiers
 	 * @return options for health element filtering
 	 */
 	fun byIdentifiersForSelf(
 		identifiers: List<Identifier>
-	): SortableFilterOptions<HealthElement> =
-		ByIdentifiersForSelf(identifiers)
+	): FilterOptions<HealthElement> = ByIdentifiersForSelf(identifiers)
 
 	/**
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with a specific data owner that have a certain code.
@@ -137,8 +132,6 @@ object HealthElementFilters {
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with the current data owner that have a certain code.
 	 * If you specify only the [codeType] you will get all entities that have at least a code of that type.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by [codeCode].
-	 *
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
 	 * with a code of the provided type.
@@ -147,7 +140,7 @@ object HealthElementFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): SortableFilterOptions<HealthElement> = ByCodeForSelf(
+	): FilterOptions<HealthElement> = ByCodeForSelf(
 		codeType = codeType,
 		codeCode = codeCode
 	)
@@ -192,8 +185,6 @@ object HealthElementFilters {
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with the current data owner that have a certain tag.
 	 * If you specify only the [tagType] you will get all entities that have at least a tag of that type.
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by [tagCode].
-	 *
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
 	 * with a tag of the provided type.
@@ -202,7 +193,7 @@ object HealthElementFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): SortableFilterOptions<HealthElement> = ByTagForSelf(
+	): FilterOptions<HealthElement> = ByTagForSelf(
 			tagType = tagType,
 			tagCode = tagCode
 		)
@@ -256,15 +247,12 @@ object HealthElementFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the health elements will be sorted by the patients, using
-	 * the same order as the input patients.
-	 *
 	 * @param patients a list of patients.
 	 */
 	@OptIn(InternalIcureApi::class)
 	fun byPatientsForSelf(
 		patients: List<Patient>
-	): SortableFilterOptions<HealthElement> = ByPatientsForSelf(
+	): FilterOptions<HealthElement> = ByPatientsForSelf(
 		patients = patients.map { it.toEncryptionMetadataStub() }
 	)
 
@@ -299,13 +287,11 @@ object HealthElementFilters {
 	/**
 	 * Options for health element filtering which match all health elements shared directly (i.e. ignoring hierarchies) with the current data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the health elements will be sorted by the linked patients
-	 * secret id, using the same order as the input.
 	 * @param secretIds a list of patients secret ids
 	 */
 	fun byPatientsSecretIdsForSelf(
 		secretIds: List<String>
-	): SortableFilterOptions<HealthElement> = ByPatientsSecretIdsForSelf(secretIds = secretIds)
+	): FilterOptions<HealthElement> = ByPatientsSecretIdsForSelf(secretIds = secretIds)
 
 	/**
 	 * Filter options that match all health elements with one of the provided ids.
@@ -520,7 +506,7 @@ object HealthElementFilters {
 	@Serializable
 	internal class ByIdentifiersForSelf(
 		val identifiers: List<Identifier>,
-	): SortableFilterOptions<HealthElement>
+	): FilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByCodeForDataOwner(
@@ -533,7 +519,7 @@ object HealthElementFilters {
 	internal class ByCodeForSelf(
 		val codeType: String,
 		val codeCode: String?,
-	): SortableFilterOptions<HealthElement>
+	): FilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByTagForDataOwner(
@@ -546,7 +532,7 @@ object HealthElementFilters {
 	internal class ByTagForSelf(
 		val tagType: String,
 		val tagCode: String?,
-	): SortableFilterOptions<HealthElement>
+	): FilterOptions<HealthElement>
 
 	@Serializable
 	@InternalIcureApi
@@ -559,7 +545,7 @@ object HealthElementFilters {
 	@InternalIcureApi
 	internal class ByPatientsForSelf(
 		val patients: List<EntityWithEncryptionMetadataStub>
-	) : SortableFilterOptions<HealthElement>
+	) : FilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForDataOwner(
@@ -570,7 +556,7 @@ object HealthElementFilters {
 	@Serializable
 	internal class ByPatientsSecretIdsForSelf(
 		val secretIds: List<String>
-	): SortableFilterOptions<HealthElement>
+	): FilterOptions<HealthElement>
 
 	@Serializable
 	internal class ByIds(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MaintenanceTaskFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MaintenanceTaskFilters.kt
@@ -28,9 +28,6 @@ object MaintenanceTaskFilters {
      * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
      * [identifiers]. Other properties of the provided identifiers are ignored.
      *
-     * These options are sortable. When sorting using these options the maintenance tasks will be in the same order as the input
-     * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-     * sorting.
      * @param dataOwnerId a data owner id
      * @param identifiers a list of identifiers
      * @return options for maintenance task filtering
@@ -38,7 +35,7 @@ object MaintenanceTaskFilters {
     fun byIdentifiersForDataOwner(
         dataOwnerId: String,
         identifiers: List<Identifier>
-    ): BaseSortableFilterOptions<MaintenanceTask> =
+    ): BaseFilterOptions<MaintenanceTask> =
         ByIdentifiersForDataOwner(identifiers, dataOwnerId)
 
     /**
@@ -122,7 +119,7 @@ object MaintenanceTaskFilters {
     internal class ByIdentifiersForDataOwner(
         val identifiers : List<Identifier>,
         val dataOwnerId: String
-    ): BaseSortableFilterOptions<MaintenanceTask>
+    ): BaseFilterOptions<MaintenanceTask>
 
     @Serializable
     internal class ByIdentifiersForSelf(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MaintenanceTaskFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MaintenanceTaskFilters.kt
@@ -46,16 +46,12 @@ object MaintenanceTaskFilters {
      * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
      * [identifiers]. Other properties of the provided identifiers are ignored.
      *
-     * These options are sortable. When sorting using these options the maintenance tasks will be in the same order as the input
-     * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-     * sorting.
      * @param identifiers a list of identifiers
      * @return options for maintenance task filtering
      */
     fun byIdentifiersForSelf(
         identifiers: List<Identifier>,
-    ): SortableFilterOptions<MaintenanceTask> =
-        ByIdentifiersForSelf(identifiers)
+    ): FilterOptions<MaintenanceTask> = ByIdentifiersForSelf(identifiers)
 
     /**
      * Options for maintenance task filtering which match all the maintenance tasks shared directly (i.e. ignoring hierarchies) with a specific data owner
@@ -131,7 +127,7 @@ object MaintenanceTaskFilters {
     @Serializable
     internal class ByIdentifiersForSelf(
         val identifiers : List<Identifier>
-    ): SortableFilterOptions<MaintenanceTask>
+    ): FilterOptions<MaintenanceTask>
 
     @Serializable
     internal class ByTypeForDataOwner(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MessageFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MessageFilters.kt
@@ -30,7 +30,6 @@ import com.icure.utils.InternalIcureApi
 import kotlinx.coroutines.currentCoroutineContext
 import kotlin.time.Instant
 import kotlinx.serialization.Serializable
-import kotlin.coroutines.coroutineContext
 
 object MessageFilters {
 	/**
@@ -80,13 +79,11 @@ object MessageFilters {
 	 * Creates options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with the current data owner that have the
 	 * provided transportGuid.
 	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [Message.sent].
-	 *
 	 * @param transportGuid a message transport guid
 	 */
 	fun byTransportGuidForSelf(
 		transportGuid: String,
-	): SortableFilterOptions<Message> = ByTransportGuidForSelf(transportGuid)
+	): FilterOptions<Message> = ByTransportGuidForSelf(transportGuid)
 
 	/**
 	 * Filter options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with a specific data owner
@@ -563,8 +560,6 @@ object MessageFilters {
 	 * Options for message filtering which match all messages shared directly (i.e. ignoring hierarchies) with the current data owner that have a certain code.
 	 * If you specify only the [codeType] you will get all entities that have at least a code of that type.
 	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [codeCode].
-	 *
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
 	 * with a code of the provided type.
@@ -573,7 +568,7 @@ object MessageFilters {
 		codeType: String,
 		@DefaultValue("null")
 		codeCode: String? = null
-	): SortableFilterOptions<Message> = ByCodeForSelf(
+	): FilterOptions<Message> = ByCodeForSelf(
 		codeType = codeType,
 		codeCode = codeCode
 	)
@@ -618,8 +613,6 @@ object MessageFilters {
 	 * Options for message filtering which match all messages shared directly (i.e. ignoring hierarchies) with the current data owner that have a certain tag.
 	 * If you specify only the [tagType] you will get all entities that have at least a tag of that type.
 	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [tagCode].
-	 *
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
 	 * with a tag of the provided type.
@@ -628,7 +621,7 @@ object MessageFilters {
 		tagType: String,
 		@DefaultValue("null")
 		tagCode: String? = null
-	): SortableFilterOptions<Message> = ByTagForSelf(
+	): FilterOptions<Message> = ByTagForSelf(
 		tagType = tagType,
 		tagCode = tagCode
 	)
@@ -650,7 +643,7 @@ object MessageFilters {
 	@Serializable
 	internal class ByTransportGuidForSelf(
 		val transportGuid: String
-	) : BaseSortableFilterOptions<Message>
+	) : BaseFilterOptions<Message>
 
 	@Serializable
 	internal class FromAddressForDataOwner(
@@ -774,7 +767,7 @@ object MessageFilters {
 	internal class ByCodeForSelf(
 		val codeType: String,
 		val codeCode: String?,
-	): SortableFilterOptions<Message>
+	): FilterOptions<Message>
 
 	@Serializable
 	internal class ByTagForDataOwner(
@@ -787,7 +780,7 @@ object MessageFilters {
 	internal class ByTagForSelf(
 		val tagType: String,
 		val tagCode: String?,
-	): SortableFilterOptions<Message>
+	): FilterOptions<Message>
 }
 
 @InternalIcureApi

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MessageFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/MessageFilters.kt
@@ -51,15 +51,13 @@ object MessageFilters {
 	 * Creates options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with a specific data owner that have the
 	 * provided transportGuid.
 	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [Message.sent].
-	 *
 	 * @param dataOwnerId a data owner id
 	 * @param transportGuid a message transport guid
 	 */
 	fun byTransportGuidForDataOwner(
 		dataOwnerId: String,
 		transportGuid: String
-	): BaseSortableFilterOptions<Message> = ByTransportGuidForDataOwner(
+	): BaseFilterOptions<Message> = ByTransportGuidForDataOwner(
 		transportGuid = transportGuid,
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId)
 	)
@@ -70,7 +68,7 @@ object MessageFilters {
 	fun byTransportGuidForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		transportGuid: String
-	): BaseSortableFilterOptions<Message> = ByTransportGuidForDataOwner(
+	): BaseFilterOptions<Message> = ByTransportGuidForDataOwner(
 		transportGuid = transportGuid,
 		dataOwnerId = dataOwner
 	)
@@ -346,9 +344,6 @@ object MessageFilters {
 	 * Filter options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with a specific data owner
 	 * where [Message.transportGuid] is equal to [transportGuid] and [Message.sent] is between [from] (inclusive) and [to] (inclusive).
 	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [Message.sent] in ascending or
-	 * descending order according to the value of the [descending] parameter.
-	 *
 	 * @param dataOwnerId the id of a data owner.
 	 * @param transportGuid the transport guid to use in the filter.
 	 * @param from the minimum value for [Message.sent].
@@ -362,7 +357,7 @@ object MessageFilters {
 		to: Instant?,
 		@DefaultValue("false")
 		descending: Boolean = false
-	): BaseSortableFilterOptions<Message> = ByTransportGuidSentDateForDataOwner(
+	): BaseFilterOptions<Message> = ByTransportGuidSentDateForDataOwner(
 		dataOwnerId = EntityReferenceInGroup(groupId = null, entityId = dataOwnerId),
 		transportGuid = transportGuid,
 		from = from,
@@ -380,7 +375,7 @@ object MessageFilters {
 		to: Instant?,
 		@DefaultValue("false")
 		descending: Boolean = false
-	): BaseSortableFilterOptions<Message> = ByTransportGuidSentDateForDataOwner(
+	): BaseFilterOptions<Message> = ByTransportGuidSentDateForDataOwner(
 		dataOwnerId = dataOwner,
 		transportGuid = transportGuid,
 		from = from,
@@ -391,9 +386,6 @@ object MessageFilters {
 	/**
 	 * Filter options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with the current data owner
 	 * where [Message.transportGuid] is equal to [transportGuid] and [Message.sent] is between [from] (inclusive) and [to] (inclusive).
-	 *
-	 * These options are sortable. When sorting using these options the messages will be sorted by [Message.sent] in ascending or
-	 * descending order according to the value of the [descending] parameter.
 	 *
 	 * @param transportGuid the transport guid to use in the filter.
 	 * @param from the minimum value for [Message.sent].
@@ -406,7 +398,7 @@ object MessageFilters {
 		to: Instant?,
 		@DefaultValue("false")
 		descending: Boolean = false
-	): SortableFilterOptions<Message> = ByTransportGuidSentDateForSelf(transportGuid, from, to, descending)
+	): FilterOptions<Message> = ByTransportGuidSentDateForSelf(transportGuid, from, to, descending)
 
 	/**
 	 * Filter options for message filtering that will match all messages shared directly (i.e. ignoring hierarchies) with a specific data owner
@@ -638,7 +630,7 @@ object MessageFilters {
 	internal class ByTransportGuidForDataOwner(
 		val transportGuid: String,
 		val dataOwnerId: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Message>
+	) : BaseFilterOptions<Message>
 
 	@Serializable
 	internal class ByTransportGuidForSelf(
@@ -710,7 +702,7 @@ object MessageFilters {
 		val from: Instant?,
 		val to: Instant?,
 		val descending: Boolean
-	): BaseSortableFilterOptions<Message>
+	): BaseFilterOptions<Message>
 
 	@Serializable
 	internal class ByTransportGuidSentDateForSelf(
@@ -718,7 +710,7 @@ object MessageFilters {
 		val from: Instant?,
 		val to: Instant?,
 		val descending: Boolean
-	): SortableFilterOptions<Message>
+	): FilterOptions<Message>
 
 	@Serializable
 	internal class LatestByTransportGuidForDataOwner(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/PatientFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/PatientFilters.kt
@@ -360,34 +360,26 @@ object PatientFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the patients will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
-	 *
 	 * @param identifiers a list of identifiers
 	 * @return options for patient filtering
 	 */
 	fun byIdentifiersForSelf(
 		identifiers: List<Identifier>
-	): SortableFilterOptions<Patient> =
-		ByIdentifiersForSelf(identifiers)
+	): FilterOptions<Patient> = ByIdentifiersForSelf(identifiers)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with the current data owner that have
 	 * [Patient.ssin] matching one of the provided ssins.
-	 * These options are sortable. When sorting using these options the patients will be in the same order as the
-	 * provided ssins.
 	 *
 	 * @param ssins a list of ssins
 	 */
 	fun bySsinsForSelf(
 		ssins: List<String>
-	): SortableFilterOptions<Patient> = BySsinsForSelf(ssins)
+	): FilterOptions<Patient> = BySsinsForSelf(ssins)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with the current data owner that have
 	 * [Patient.dateOfBirth] between the provided values (inclusive).
-	 * These options are sortable. When sorting using these options the patients will be ordered by date of birth.
 	 *
 	 * @param fromDate the start date in YYYYMMDD format (inclusive)
 	 * @param toDate the end date in YYYYMMDD format (inclusive)
@@ -395,7 +387,7 @@ object PatientFilters {
 	fun byDateOfBirthBetweenForSelf(
 		fromDate: Int,
 		toDate: Int
-	): SortableFilterOptions<Patient> = ByDateOfBirthBetweenForSelf(
+	): FilterOptions<Patient> = ByDateOfBirthBetweenForSelf(
 		fromDate = fromDate,
 		toDate = toDate,
 	)
@@ -416,9 +408,6 @@ object PatientFilters {
 	 * provided [Patient.gender], and optionally also the provided [Patient.education] and [Patient.profession].
 	 * Note you can only provide profession if you have provided the education.
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered first by education
-	 * then by profession.
-	 *
 	 * @param gender the patient gender.
 	 * @param education the patient education. If not provided patient the education of the patient will be ignored by
 	 * this filter.
@@ -432,7 +421,7 @@ object PatientFilters {
 		education: String? = null,
 		@DefaultValue("null")
 		profession: String? = null
-	): SortableFilterOptions<Patient> =
+	): FilterOptions<Patient> =
 		ByGenderEducationProfessionForSelf(
 			gender = gender,
 			education = education,
@@ -454,23 +443,17 @@ object PatientFilters {
 	 * an address with a [Patient.addresses] where one of the [Address.telecoms] has a [Telecom.telecomNumber] that
 	 * starts with the provided [searchString].
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically by
-	 * the matching telecom number.
-	 *
 	 * @param searchString start of a patient telecom. Non-alphanumeric characters are ignored.
 	 */
 	fun byTelecomForSelf(
 		searchString: String
-	) : SortableFilterOptions<Patient> = ByTelecomForSelf(searchString)
+	) : FilterOptions<Patient> = ByTelecomForSelf(searchString)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with the current data owner that have at least
 	 * an [Patient.addresses] where the [Address.street] or [Address.city] contain the provided [searchString] and
 	 * [Address.postalCode] matches the provided [postalCode].
-	 * Additionally you can limit the search to a specific house number.
-	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically first
-	 * by the matching portion of street+city, then by postal code and finally by house number.
+	 * Additionally, you can limit the search to a specific house number.
 	 *
 	 * @param searchString part of a patient address street or city
 	 * @param postalCode the patient postal code
@@ -481,7 +464,7 @@ object PatientFilters {
 		postalCode: String,
 		@DefaultValue("null")
 		houseNumber: String? = null
-	) : SortableFilterOptions<Patient> =
+	) : FilterOptions<Patient> =
 		ByAddressPostalCodeHouseNumberForSelf(
 			searchString = searchString,
 			postalCode = postalCode,
@@ -493,14 +476,11 @@ object PatientFilters {
 	 * an [Patient.addresses] where the [Address.street], [Address.postalCode] or [Address.city] contain the provided
 	 * [searchString].
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically first
-	 * by the matching portion of street+postalCode+city, then by postal code and finally by house number.
-	 *
 	 * @param searchString part of a patient address street, postal code, or city
 	 */
 	fun byAddressForSelf(
 		searchString: String
-	) : SortableFilterOptions<Patient> = ByAddressForSelf(searchString = searchString)
+	) : FilterOptions<Patient> = ByAddressForSelf(searchString = searchString)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with the current data owner
@@ -624,30 +604,30 @@ object PatientFilters {
 	@Serializable
 	internal class ByIdentifiersForSelf(
 		val identifiers: List<Identifier>
-	) : SortableFilterOptions<Patient>
+	) : FilterOptions<Patient>
 
 	@Serializable
 	internal class BySsinsForSelf(
 		val ssins: List<String>
-	): SortableFilterOptions<Patient>
+	): FilterOptions<Patient>
 
 	@Serializable
 	internal class ByDateOfBirthBetweenForSelf(
 		val fromDate: Int,
 		val toDate: Int
-	): SortableFilterOptions<Patient>
+	): FilterOptions<Patient>
 
 	@Serializable
 	internal class ByNameForSelf(
 		val searchString: String
-	) : SortableFilterOptions<Patient>
+	) : FilterOptions<Patient>
 
 	@Serializable
 	internal class ByGenderEducationProfessionForSelf(
 		val gender: Gender,
 		val education: String?,
 		val profession: String?
-	): SortableFilterOptions<Patient> {
+	): FilterOptions<Patient> {
 		init {
 			require (profession == null || education != null) {
 				"You must provide a value for education if you want to filter by profession"
@@ -663,19 +643,19 @@ object PatientFilters {
 	@Serializable
 	internal class ByTelecomForSelf(
 		val searchString: String
-	) : SortableFilterOptions<Patient>
+	) : FilterOptions<Patient>
 
 	@Serializable
 	internal class ByAddressPostalCodeHouseNumberForSelf(
 		val searchString: String,
 		val postalCode: String,
 		val houseNumber: String?
-	) : SortableFilterOptions<Patient>
+	) : FilterOptions<Patient>
 
 	@Serializable
 	internal class ByAddressForSelf(
 		val searchString: String
-	) : SortableFilterOptions<Patient>
+	) : FilterOptions<Patient>
 
 	@Serializable
 	internal class ByTagForDataOwner(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/PatientFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/PatientFilters.kt
@@ -76,10 +76,6 @@ object PatientFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the patients will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
-	 *
 	 * @param identifiers a list of identifiers
 	 * @param dataOwnerId a data owner id
 	 * @return options for patient filtering
@@ -87,7 +83,7 @@ object PatientFilters {
 	fun byIdentifiersForDataOwner(
 		dataOwnerId: String,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<Patient> =
+	): BaseFilterOptions<Patient> =
 		ByIdentifiersForDataOwner(identifiers, EntityReferenceInGroup(dataOwnerId, null))
 
 	/**
@@ -97,14 +93,12 @@ object PatientFilters {
 	fun byIdentifiersForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		identifiers: List<Identifier>
-	): BaseSortableFilterOptions<Patient> =
+	): BaseFilterOptions<Patient> =
 		ByIdentifiersForDataOwner(identifiers, dataOwner)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with a specific data owner that have
 	 * [Patient.ssin] matching one of the provided ssins.
-	 * These options are sortable. When sorting using these options the patients will be in the same order as the
-	 * provided ssins.
 	 *
 	 * @param ssins a list of ssins
 	 * @param dataOwnerId a data owner id
@@ -112,7 +106,7 @@ object PatientFilters {
 	fun bySsinsForDataOwner(
 		dataOwnerId: String,
 		ssins: List<String>
-	): BaseSortableFilterOptions<Patient> = BySsinsForDataOwner(ssins, EntityReferenceInGroup(dataOwnerId, null))
+	): BaseFilterOptions<Patient> = BySsinsForDataOwner(ssins, EntityReferenceInGroup(dataOwnerId, null))
 
 	/**
 	 * In-group version of [bySsinsForDataOwner].
@@ -121,12 +115,11 @@ object PatientFilters {
 	fun bySsinsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		ssins: List<String>
-	): BaseSortableFilterOptions<Patient> = BySsinsForDataOwner(ssins, dataOwner)
+	): BaseFilterOptions<Patient> = BySsinsForDataOwner(ssins, dataOwner)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with a specific data owner that have
 	 * [Patient.dateOfBirth] between the provided values (inclusive).
-	 * These options are sortable. When sorting using these options the patients will be ordered by date of birth.
 	 *
 	 * @param fromDate the start date in YYYYMMDD format (inclusive)
 	 * @param toDate the end date in YYYYMMDD format (inclusive)
@@ -136,7 +129,7 @@ object PatientFilters {
 		dataOwnerId: String,
 		fromDate: Int,
 		toDate: Int
-	): BaseSortableFilterOptions<Patient> = ByDateOfBirthBetweenForDataOwner(
+	): BaseFilterOptions<Patient> = ByDateOfBirthBetweenForDataOwner(
 		fromDate = fromDate,
 		toDate = toDate,
 		dataOwner = EntityReferenceInGroup(dataOwnerId, null)
@@ -150,7 +143,7 @@ object PatientFilters {
 		dataOwner: EntityReferenceInGroup,
 		fromDate: Int,
 		toDate: Int
-	): BaseSortableFilterOptions<Patient> = ByDateOfBirthBetweenForDataOwner(
+	): BaseFilterOptions<Patient> = ByDateOfBirthBetweenForDataOwner(
 		fromDate = fromDate,
 		toDate = toDate,
 		dataOwner = dataOwner
@@ -185,9 +178,6 @@ object PatientFilters {
 	 * provided [Patient.gender], and optionally also the provided [Patient.education] and [Patient.profession].
 	 * Note you can only provide profession if you have provided the education.
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered first by education
-	 * then by profession.
-	 *
 	 * @param gender the patient gender.
 	 * @param education the patient education. If not provided patient the education of the patient will be ignored by
 	 * this filter.
@@ -203,7 +193,7 @@ object PatientFilters {
 		education: String? = null,
 		@DefaultValue("null")
 		profession: String? = null
-	): BaseSortableFilterOptions<Patient> =
+	): BaseFilterOptions<Patient> =
 		ByGenderEducationProfessionForDataOwner(
 			gender = gender,
 			education = education,
@@ -222,7 +212,7 @@ object PatientFilters {
 		education: String? = null,
 		@DefaultValue("null")
 		profession: String? = null
-	): BaseSortableFilterOptions<Patient> =
+	): BaseFilterOptions<Patient> =
 		ByGenderEducationProfessionForDataOwner(
 			gender = gender,
 			education = education,
@@ -256,16 +246,13 @@ object PatientFilters {
 	 * an address with a [Patient.addresses] where one of the [Address.telecoms] has a [Telecom.telecomNumber] that
 	 * starts with the provided [searchString].
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically by
-	 * the matching telecom number.
-	 *
 	 * @param searchString start of a patient telecom. Non-alphanumeric characters are ignored.
 	 * @param dataOwnerId a data owner id
 	 */
 	fun byTelecomForDataOwner(
 		dataOwnerId: String,
 		searchString: String
-	) : BaseSortableFilterOptions<Patient> = ByTelecomForDataOwner(searchString, EntityReferenceInGroup(dataOwnerId, null))
+	) : BaseFilterOptions<Patient> = ByTelecomForDataOwner(searchString, EntityReferenceInGroup(dataOwnerId, null))
 
 	/**
 	 * In-group version of [byTelecomForDataOwner].
@@ -274,16 +261,13 @@ object PatientFilters {
 	fun byTelecomForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		searchString: String
-	) : BaseSortableFilterOptions<Patient> = ByTelecomForDataOwner(searchString, dataOwner)
+	) : BaseFilterOptions<Patient> = ByTelecomForDataOwner(searchString, dataOwner)
 
 	/**
 	 * Options for patient filtering which match all the patients shared directly (i.e. ignoring hierarchies) with a specific data owner that have at least
 	 * an [Patient.addresses] where the [Address.street] or [Address.city] contain the provided [searchString] and
 	 * [Address.postalCode] matches the provided [postalCode].
-	 * Additionally you can limit the search to a specific house number.
-	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically first
-	 * by the matching portion of street+city, then by postal code and finally by house number.
+	 * Additionally, you can limit the search to a specific house number.
 	 *
 	 * @param searchString part of a patient address street or city
 	 * @param postalCode the patient postal code
@@ -296,7 +280,7 @@ object PatientFilters {
 		postalCode: String,
 		@DefaultValue("null")
 		houseNumber: String? = null
-	) : BaseSortableFilterOptions<Patient> =
+	) : BaseFilterOptions<Patient> =
 		ByAddressPostalCodeHouseNumberForDataOwner(
 			searchString = searchString,
 			postalCode = postalCode,
@@ -314,7 +298,7 @@ object PatientFilters {
 		postalCode: String,
 		@DefaultValue("null")
 		houseNumber: String? = null
-	) : BaseSortableFilterOptions<Patient> =
+	) : BaseFilterOptions<Patient> =
 		ByAddressPostalCodeHouseNumberForDataOwner(
 			searchString = searchString,
 			postalCode = postalCode,
@@ -327,16 +311,13 @@ object PatientFilters {
 	 * an [Patient.addresses] where the [Address.street], [Address.postalCode] or [Address.city] contain the provided
 	 * [searchString].
 	 *
-	 * These options are sortable. When sorting using these options the patients will be ordered lexicographically first
-	 * by the matching portion of street+postalCode+city, then by postal code and finally by house number.
-	 *
 	 * @param searchString part of a patient address street, postal code, or city
 	 * @param dataOwnerId a data owner id
 	 */
 	fun byAddressForDataOwner(
 		dataOwnerId: String,
 		searchString: String
-	) : BaseSortableFilterOptions<Patient> =
+	) : BaseFilterOptions<Patient> =
 		ByAddressForDataOwner(
 			searchString = searchString,
 			dataOwner = EntityReferenceInGroup(dataOwnerId, null)
@@ -349,7 +330,7 @@ object PatientFilters {
 	fun byAddressForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		searchString: String
-	) : BaseSortableFilterOptions<Patient> =
+	) : BaseFilterOptions<Patient> =
 		ByAddressForDataOwner(
 			searchString = searchString,
 			dataOwner = dataOwner
@@ -540,26 +521,26 @@ object PatientFilters {
 	internal class ByIdentifiersForDataOwner(
 		val identifiers: List<Identifier>,
 		val dataOwner: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Patient>
+	) : BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class BySsinsForDataOwner(
 		val ssins: List<String>,
 		val dataOwner: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Patient>
+	): BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByDateOfBirthBetweenForDataOwner(
 		val fromDate: Int,
 		val toDate: Int,
 		val dataOwner: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Patient>
+	): BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByNameForDataOwner(
 		val searchString: String,
 		val dataOwner: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Patient>
+	) : BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByGenderEducationProfessionForDataOwner(
@@ -567,7 +548,7 @@ object PatientFilters {
 		val education: String?,
 		val profession: String?,
 		val dataOwner: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Patient> {
+	): BaseFilterOptions<Patient> {
 		init {
 			require (profession == null || education != null) {
 				"You must provide a value for education if you want to filter by profession"
@@ -585,7 +566,7 @@ object PatientFilters {
 	internal class ByTelecomForDataOwner(
 		val searchString: String,
 		val dataOwner: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Patient>
+	) : BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByAddressPostalCodeHouseNumberForDataOwner(
@@ -593,13 +574,13 @@ object PatientFilters {
 		val postalCode: String,
 		val houseNumber: String?,
 		val dataOwner: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Patient>
+	) : BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByAddressForDataOwner(
 		val searchString: String,
 		val dataOwner: EntityReferenceInGroup
-	) : BaseSortableFilterOptions<Patient>
+	) : BaseFilterOptions<Patient>
 
 	@Serializable
 	internal class ByIdentifiersForSelf(

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ServiceFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ServiceFilters.kt
@@ -73,9 +73,6 @@ object ServiceFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the services will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
 	 * @param identifiers a list of identifiers
 	 * @param dataOwnerId a data owner id
 	 * @return options for service filtering
@@ -83,7 +80,7 @@ object ServiceFilters {
 	fun byIdentifiersForDataOwner(
 		dataOwnerId: String,
 		identifiers: List<Identifier>,
-	): BaseSortableFilterOptions<Service> = ByIdentifiersForDataOwner(
+	): BaseFilterOptions<Service> = ByIdentifiersForDataOwner(
 		identifiers = identifiers,
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null)
 	)
@@ -94,7 +91,7 @@ object ServiceFilters {
 	fun byIdentifiersForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		identifiers: List<Identifier>,
-	): BaseSortableFilterOptions<Service> = ByIdentifiersForDataOwner(
+	): BaseFilterOptions<Service> = ByIdentifiersForDataOwner(
 		identifiers = identifiers,
 		dataOwnerId = dataOwner
 	)
@@ -105,9 +102,6 @@ object ServiceFilters {
 	 *
 	 * You can also limit the result to only services that are within a certain [Service.valueDate] timeframe (or [Service.openingDate]
 	 * if the first is missing), but in that case you must specify the [codeCode].
-	 *
-	 * These options are sortable. When sorting using these options the services will be sorted first by [codeCode] then
-	 * by [Service.valueDate].
 	 *
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
@@ -128,7 +122,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): BaseSortableFilterOptions<Service> = ByCodeAndValueDateForDataOwner(
+	): BaseFilterOptions<Service> = ByCodeAndValueDateForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -148,7 +142,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): BaseSortableFilterOptions<Service> = ByCodeAndValueDateForDataOwner(
+	): BaseFilterOptions<Service> = ByCodeAndValueDateForDataOwner(
 		codeType = codeType,
 		codeCode = codeCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -162,9 +156,6 @@ object ServiceFilters {
 	 *
 	 * You can also limit the result to only services that are within a certain [Service.valueDate] timeframe (or [Service.openingDate]
 	 * if the first is missing), but in that case you must specify the [tagCode].
-	 *
-	 * These options are sortable. When sorting using these options the services will be sorted first by [tagCode] then
-	 * by [Service.valueDate].
 	 *
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
@@ -185,7 +176,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): BaseSortableFilterOptions<Service> = ByTagAndValueDateForDataOwner(
+	): BaseFilterOptions<Service> = ByTagAndValueDateForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -205,7 +196,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): BaseSortableFilterOptions<Service> = ByTagAndValueDateForDataOwner(
+	): BaseFilterOptions<Service> = ByTagAndValueDateForDataOwner(
 		tagType = tagType,
 		tagCode = tagCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -224,8 +215,6 @@ object ServiceFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the services will be sorted by the patients, using
-	 * the same order as the input patients.
 	 * @param patients a list of patients.
 	 * @param dataOwnerId a data owner id
 	 */
@@ -233,7 +222,7 @@ object ServiceFilters {
 	fun byPatientsForDataOwner(
 		dataOwnerId: String,
 		patients: List<Patient>,
-	): SortableFilterOptions<Service> = ByPatientsForDataOwner(
+	): FilterOptions<Service> = ByPatientsForDataOwner(
 		patients = patients.map { it.toEncryptionMetadataStub() },
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null)
 	)
@@ -245,7 +234,7 @@ object ServiceFilters {
 	fun byPatientsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		patients: List<Patient>,
-	): SortableFilterOptions<Service> = ByPatientsForDataOwner(
+	): FilterOptions<Service> = ByPatientsForDataOwner(
 		patients = patients.map { it.toEncryptionMetadataStub() },
 		dataOwnerId = dataOwner
 	)
@@ -253,15 +242,14 @@ object ServiceFilters {
 	/**
 	 * Options for service filtering which match all services shared directly (i.e. ignoring hierarchies) with a specific data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the services will be sorted by the linked patients
-	 * secret id, using the same order as the input.
+	 *
 	 * @param secretIds a list of patients secret ids
 	 * @param dataOwnerId a data owner id
 	 */
 	fun byPatientsSecretIdsForDataOwner(
 		dataOwnerId: String,
 		secretIds: List<String>,
-	): BaseSortableFilterOptions<Service> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<Service> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null)
 	)
@@ -272,7 +260,7 @@ object ServiceFilters {
 	fun byPatientsSecretIdsForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		secretIds: List<String>,
-	): BaseSortableFilterOptions<Service> = ByPatientsSecretIdsForDataOwner(
+	): BaseFilterOptions<Service> = ByPatientsSecretIdsForDataOwner(
 		secretIds = secretIds,
 		dataOwnerId = dataOwner
 	)
@@ -283,16 +271,13 @@ object ServiceFilters {
 	 * least a [SubContact] (from [Contact.subContacts]) where [SubContact.healthElementId] matches one of the provided
 	 * id.
 	 *
-	 * These options are sortable. When sorting using these options the services will be sorted in the same order as the
-	 * input health element ids. If a service exists in multiple subcontacts only the first subcontact with matching
-	 * health element service is considered for the ordering.
 	 * @param healthElementIds a list of health element ids
 	 * @param dataOwnerId a data owner id
 	 */
 	fun byHealthElementIdFromSubContactForDataOwner(
 		dataOwnerId: String,
 		healthElementIds: List<String>,
-	): BaseSortableFilterOptions<Service> = ByHealthElementIdFromSubcontactForDataOwner(
+	): BaseFilterOptions<Service> = ByHealthElementIdFromSubcontactForDataOwner(
 		healthElementIds = healthElementIds,
 		dataOwnerId = EntityReferenceInGroup(entityId = dataOwnerId, groupId = null)
 	)
@@ -303,7 +288,7 @@ object ServiceFilters {
 	fun byHealthElementIdFromSubContactForDataOwnerInGroup(
 		dataOwner: EntityReferenceInGroup,
 		healthElementIds: List<String>,
-	): BaseSortableFilterOptions<Service> = ByHealthElementIdFromSubcontactForDataOwner(
+	): BaseFilterOptions<Service> = ByHealthElementIdFromSubcontactForDataOwner(
 		healthElementIds = healthElementIds,
 		dataOwnerId = dataOwner
 	)
@@ -329,9 +314,6 @@ object ServiceFilters {
 	 * You can also limit the result to only services that are within a certain [Service.valueDate] timeframe (or [Service.openingDate]
 	 * if the first is missing), but in that case you must specify the [codeCode].
 	 *
-	 * These options are sortable. When sorting using these options the services will be sorted first by [codeCode] then
-	 * by [Service.valueDate].
-	 *
 	 * @param codeType a code type
 	 * @param codeCode a code for the provided code type, or null if you want the filter to accept any entity
 	 * with a code of the provided type.
@@ -349,7 +331,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): SortableFilterOptions<Service> = ByCodeAndValueDateForSelf(
+	): FilterOptions<Service> = ByCodeAndValueDateForSelf(
 		codeType = codeType,
 		codeCode = codeCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -362,9 +344,6 @@ object ServiceFilters {
 	 *
 	 * You can also limit the result to only services that are within a certain [Service.valueDate] timeframe (or [Service.openingDate]
 	 * if the first is missing), but in that case you must specify the [tagCode].
-	 *
-	 * These options are sortable. When sorting using these options the services will be sorted first by [tagCode] then
-	 * by [Service.valueDate].
 	 *
 	 * @param tagType a tag type
 	 * @param tagCode a code for the provided tag type, or null if you want the filter to accept any entity
@@ -383,7 +362,7 @@ object ServiceFilters {
 		startOfServiceValueDate: Long? = null,
 		@DefaultValue("null")
 		endOfServiceValueDate: Long? = null,
-	): SortableFilterOptions<Service> = ByTagAndValueDateForSelf(
+	): FilterOptions<Service> = ByTagAndValueDateForSelf(
 		tagType = tagType,
 		tagCode = tagCode,
 		startOfServiceValueDate = startOfServiceValueDate,
@@ -1262,7 +1241,7 @@ object ServiceFilters {
 	internal class ByIdentifiersForDataOwner(
 		val identifiers: List<Identifier>,
 		val dataOwnerId: EntityReferenceInGroup,
-	) : BaseSortableFilterOptions<Service>
+	) : BaseFilterOptions<Service>
 
 	@Serializable
 	internal class ByCodeAndValueDateForDataOwner(
@@ -1271,7 +1250,7 @@ object ServiceFilters {
 		val startOfServiceValueDate: Long?,
 		val endOfServiceValueDate: Long?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Service> {
+	): BaseFilterOptions<Service> {
 		init {
 			require (codeCode != null || (startOfServiceValueDate == null && endOfServiceValueDate == null)) {
 				"Code code is mandatory if you want to restrict the range of service value date"
@@ -1286,7 +1265,7 @@ object ServiceFilters {
 		val startOfServiceValueDate: Long?,
 		val endOfServiceValueDate: Long?,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Service> {
+	): BaseFilterOptions<Service> {
 		init {
 			require (tagCode != null || (startOfServiceValueDate == null && endOfServiceValueDate == null)) {
 				"Tag code is mandatory if you want to restrict the range of service value date"
@@ -1299,19 +1278,19 @@ object ServiceFilters {
 	internal class ByPatientsForDataOwner(
 		val patients: List<EntityWithEncryptionMetadataStub>,
 		val dataOwnerId: EntityReferenceInGroup,
-	): SortableFilterOptions<Service>
+	): FilterOptions<Service>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForDataOwner(
 		val secretIds: List<String>,
 		val dataOwnerId: EntityReferenceInGroup,
-	): BaseSortableFilterOptions<Service>
+	): BaseFilterOptions<Service>
 
 	@Serializable
 	internal class ByHealthElementIdFromSubcontactForDataOwner(
 		val healthElementIds: List<String>,
 		val dataOwnerId: EntityReferenceInGroup
-	): BaseSortableFilterOptions<Service>
+	): BaseFilterOptions<Service>
 
 	@Serializable
 	internal data object AllForSelf : FilterOptions<Service>
@@ -1327,7 +1306,7 @@ object ServiceFilters {
 		val codeCode: String?,
 		val startOfServiceValueDate: Long?,
 		val endOfServiceValueDate: Long?
-	): SortableFilterOptions<Service> {
+	): FilterOptions<Service> {
 		init {
 			require (codeCode != null || (startOfServiceValueDate == null && endOfServiceValueDate == null)) {
 				"Code code is mandatory if you want to restrict the range of service value date"
@@ -1341,7 +1320,7 @@ object ServiceFilters {
 		val tagCode: String?,
 		val startOfServiceValueDate: Long?,
 		val endOfServiceValueDate: Long?
-	): SortableFilterOptions<Service> {
+	): FilterOptions<Service> {
 		init {
 			require (tagCode != null || (startOfServiceValueDate == null && endOfServiceValueDate == null)) {
 				"Tag code is mandatory if you want to restrict the range of service value date"

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ServiceFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/ServiceFilters.kt
@@ -314,15 +314,12 @@ object ServiceFilters {
 	 * an identifier that has the same exact [Identifier.system] and [Identifier.value] as one of the provided
 	 * [identifiers]. Other properties of the provided identifiers are ignored.
 	 *
-	 * These options are sortable. When sorting using these options the services will be in the same order as the input
-	 * identifiers. In case an entity has multiple identifiers only the first matching identifier is considered for the
-	 * sorting.
 	 * @param identifiers a list of identifiers
 	 * @return options for service filtering
 	 */
 	fun byIdentifiersForSelf(
 		identifiers: List<Identifier>,
-	): SortableFilterOptions<Service> =
+	): FilterOptions<Service> =
 		ByIdentifiersForSelf(identifiers)
 
 	/**
@@ -404,29 +401,24 @@ object ServiceFilters {
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
-	 * These options are sortable. When sorting using these options the services will be sorted by the patients, using
-	 * the same order as the input patients.
-	 *
 	 * @param patients a list of patients.
 	 */
 	@OptIn(InternalIcureApi::class)
 	fun byPatientsForSelf(
 		patients: List<Patient>,
-	): SortableFilterOptions<Service> = ByPatientsForSelf(
+	): FilterOptions<Service> = ByPatientsForSelf(
 		patients = patients.map { it.toEncryptionMetadataStub() },
 	)
 
 	/**
 	 * Options for service filtering which match all services shared directly (i.e. ignoring hierarchies) with the current data owner that are linked with a
 	 * patient through one of the provided secret ids.
-	 * These options are sortable. When sorting using these options the services will be sorted by the linked patients
-	 * secret id, using the same order as the input.
 	 *
 	 * @param secretIds a list of patients secret ids
 	 */
 	fun byPatientsSecretIdsForSelf(
 		secretIds: List<String>,
-	): SortableFilterOptions<Service> = ByPatientsSecretIdsForSelf(
+	): FilterOptions<Service> = ByPatientsSecretIdsForSelf(
 		secretIds = secretIds,
 	)
 
@@ -436,15 +428,11 @@ object ServiceFilters {
 	 * least a [SubContact] (from [Contact.subContacts]) where [SubContact.healthElementId] matches one of the provided
 	 * id.
 	 *
-	 * These options are sortable. When sorting using these options the services will be sorted in the same order as the
-	 * input health element ids. If a service exists in multiple subcontacts only the first subcontact with matching
-	 * health element service is considered for the ordering.
-	 *
 	 * @param healthElementIds a list of health element ids
 	 */
 	fun byHealthElementIdFromSubContactForSelf(
 		healthElementIds: List<String>,
-	): SortableFilterOptions<Service> = ByHealthElementIdFromSubcontactForSelf(
+	): FilterOptions<Service> = ByHealthElementIdFromSubcontactForSelf(
 		healthElementIds = healthElementIds,
 	)
 
@@ -1331,7 +1319,7 @@ object ServiceFilters {
 	@Serializable
 	internal class ByIdentifiersForSelf(
 		val identifiers: List<Identifier>
-	) : SortableFilterOptions<Service>
+	) : FilterOptions<Service>
 
 	@Serializable
 	internal class ByCodeAndValueDateForSelf(
@@ -1365,17 +1353,17 @@ object ServiceFilters {
 	@InternalIcureApi
 	internal class ByPatientsForSelf(
 		val patients: List<EntityWithEncryptionMetadataStub>
-	): SortableFilterOptions<Service>
+	): FilterOptions<Service>
 
 	@Serializable
 	internal class ByPatientsSecretIdsForSelf(
 		val secretIds: List<String>
-	): SortableFilterOptions<Service>
+	): FilterOptions<Service>
 
 	@Serializable
 	internal class ByHealthElementIdFromSubcontactForSelf(
 		val healthElementIds: List<String>
-	): SortableFilterOptions<Service>
+	): FilterOptions<Service>
 
 	@Serializable
 	internal class ByIds(


### PR DESCRIPTION
## Scope of the PR
Some filters FilterXByYForSelf were marked as sortable on field(s) Y. However, they rely on views where the search key of the data owner is the first element of the view key and there is no further ordering, so in a case where the current dataowner has multiple search keys, the results will not actually be sorted.
The Sorted subtype was removed also from the FilterXByYForDataOwner version of the same filters, because a user could potentially use their own dataOwnerId and get the same behaviour as the ForSelf filter.