### PR TITLE
Expose CalendarItem occupancy on full API; fix Medication KDoc bug

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/CalendarItemApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/CalendarItemApi.kt
@@ -585,6 +585,55 @@ interface CalendarItemApi : CalendarItemBasicFlavourlessApi, CalendarItemFlavour
 	 * @return a list of calendarItem ids
 	 */
 	suspend fun matchCalendarItemsBySorted(filter: SortableFilterOptions<CalendarItem>): List<String>
+
+	/**
+	 * Computes the concurrent-occupancy histogram of the calendar items for the current data owner over the
+	 * period [startDate]..[endDate] (fuzzy date-times, either bound may be null = open).
+	 *
+	 * Only calendar items whose whole interval fits within the search range are considered. By default, the
+	 * range is exactly [startDate]..[endDate], so items starting before [startDate] or ending after [endDate]
+	 * are ignored. Pass [extensionInDays] to widen the range by that many days on each side, which lets items
+	 * that start shortly before [startDate] (contributing to the occupancy baseline) or end shortly after
+	 * [endDate] be taken into account. Items reaching beyond the extended range are still ignored.
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodForSelf(
+		startDate: Long,
+		endDate: Long,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
+
+	/**
+	 * Computes the concurrent-occupancy histogram of the calendar items of [hcPartyId] over the
+	 * period [startDate]..[endDate] (fuzzy date-times, either bound may be null = open).
+	 *
+	 * Only calendar items whose whole interval fits within the search range are considered. By default, the
+	 * range is exactly [startDate]..[endDate], so items starting before [startDate] or ending after [endDate]
+	 * are ignored. Pass [extensionInDays] to widen the range by that many days on each side, which lets items
+	 * that start shortly before [startDate] (contributing to the occupancy baseline) or end shortly after
+	 * [endDate] be taken into account. Items reaching beyond the extended range are still ignored.
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodForHealthcareParty(
+		startDate: Long,
+		endDate: Long,
+		hcPartyId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
+
+	/**
+	 * Computes the concurrent-occupancy histogram of the calendar items of the agenda [agendaId] over the
+	 * period [startDate]..[endDate] (fuzzy date-times, either bound may be null = open).
+	 *
+	 * Only calendar items whose whole interval fits within the search range are considered. By default, the range
+	 * is exactly [startDate]..[endDate], you can pass a non-null [extensionInDays] to widen it by that many days on each side (e.g.
+	 * to include items that start before [startDate] but are still open during the period). Items reaching beyond
+	 * the extended range are ignored.
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodAndAgendaId(
+		startDate: Long,
+		endDate: Long,
+		agendaId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
 }
 
 interface CalendarItemInGroupApi : CalendarItemBasicFlavourlessInGroupApi, CalendarItemFlavouredInGroupApi<DecryptedCalendarItem> { // TODO subscribable?
@@ -659,6 +708,38 @@ interface CalendarItemInGroupApi : CalendarItemBasicFlavourlessInGroupApi, Calen
 	 * In-group version of [CalendarItemApi.matchCalendarItemsBySorted]
 	 */
 	 suspend fun matchCalendarItemsBySorted(groupId: String, filter: SortableFilterOptions<CalendarItem>): List<String>
+
+	/**
+	 * In-group version of [CalendarItemApi.getCalendarItemsOccupancyByPeriodForSelf].
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodForSelf(
+		groupId: String,
+		startDate: Long,
+		endDate: Long,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
+
+	/**
+	 * In-group version of [CalendarItemApi.getCalendarItemsOccupancyByPeriodForHealthcareParty].
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodForHealthcareParty(
+		groupId: String,
+		startDate: Long,
+		endDate: Long,
+		hcPartyId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
+
+	/**
+	 * In-group version of [CalendarItemApi.getCalendarItemsOccupancyByPeriodAndAgendaId].
+	 */
+	suspend fun getCalendarItemsOccupancyByPeriodAndAgendaId(
+		groupId: String,
+		startDate: Long,
+		endDate: Long,
+		agendaId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy>
 }
 
 interface CalendarItemBasicApi : CalendarItemBasicFlavourlessApi, CalendarItemBasicFlavouredApi<EncryptedCalendarItem>,

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
@@ -622,6 +622,50 @@ private class CalendarItemApiImpl(
 			groupId: String,
 			filter: SortableFilterOptions<CalendarItem>,
 		): List<String> = doMatchCalendarItemsBySorted(groupId, filter)
+
+		override suspend fun getCalendarItemsOccupancyByPeriodForHealthcareParty(
+			groupId: String,
+			startDate: Long,
+			endDate: Long,
+			hcPartyId: String,
+			extensionInDays: Int?
+		): List<CalendarItemOccupancy> = doGetCalendarItemsOccupancyByPeriodForHealthcareParty(
+			groupId = groupId,
+			startDate = startDate,
+			endDate = endDate,
+			hcPartyId = hcPartyId,
+			extensionInDays = extensionInDays,
+		)
+
+		override suspend fun getCalendarItemsOccupancyByPeriodForSelf(
+			groupId: String,
+			startDate: Long,
+			endDate: Long,
+			extensionInDays: Int?
+		): List<CalendarItemOccupancy> {
+			val currentHcPartyReference = config.crypto.dataOwnerApi.getCurrentDataOwnerReference()
+			return doGetCalendarItemsOccupancyByPeriodForHealthcareParty(
+				groupId = groupId,
+				startDate = startDate,
+				endDate = endDate,
+				hcPartyId = currentHcPartyReference.asReferenceStringInGroup(groupId, null),
+				extensionInDays = extensionInDays,
+			)
+		}
+
+		override suspend fun getCalendarItemsOccupancyByPeriodAndAgendaId(
+			groupId: String,
+			startDate: Long,
+			endDate: Long,
+			agendaId: String,
+			extensionInDays: Int?
+		): List<CalendarItemOccupancy> = doGetCalendarItemsOccupancyByPeriodAndAgendaId(
+			groupId = groupId,
+			startDate = startDate,
+			endDate = endDate,
+			agendaId = agendaId,
+			extensionInDays = extensionInDays,
+		)
 	}
 
 	private val crypto get() = config.crypto
@@ -755,6 +799,93 @@ private class CalendarItemApiImpl(
 		filter: SortableFilterOptions<CalendarItem>
 	): List<String> =
 		doMatchCalendarItemsBy(groupId, filter)
+
+	override suspend fun getCalendarItemsOccupancyByPeriodForHealthcareParty(
+		startDate: Long,
+		endDate: Long,
+		hcPartyId: String,
+		extensionInDays: Int?
+	): List<CalendarItemOccupancy> = doGetCalendarItemsOccupancyByPeriodForHealthcareParty(
+		groupId = null,
+		startDate = startDate,
+		endDate = endDate,
+		hcPartyId = hcPartyId,
+		extensionInDays = extensionInDays,
+	)
+
+	override suspend fun getCalendarItemsOccupancyByPeriodForSelf(
+		startDate: Long,
+		endDate: Long,
+		extensionInDays: Int?
+	): List<CalendarItemOccupancy> {
+		val currentHcPartyId = config.crypto.dataOwnerApi.getCurrentDataOwnerId()
+		return doGetCalendarItemsOccupancyByPeriodForHealthcareParty(
+			groupId = null,
+			startDate = startDate,
+			endDate = endDate,
+			hcPartyId = currentHcPartyId,
+			extensionInDays = extensionInDays,
+		)
+	}
+
+	private suspend fun doGetCalendarItemsOccupancyByPeriodForHealthcareParty(
+		groupId: String?,
+		startDate: Long,
+		endDate: Long,
+		hcPartyId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy> = if (groupId == null) {
+		rawApi.getCalendarItemsOccupancyByPeriodAndHcPartyId(
+			startDate = startDate,
+			endDate = endDate,
+			hcPartyId = hcPartyId,
+			extensionInDays = extensionInDays
+		).successBody()
+	} else {
+		rawApi.getCalendarItemsOccupancyByPeriodAndHcPartyIdInGroup(
+			groupId = groupId,
+			startDate = startDate,
+			endDate = endDate,
+			hcPartyId = hcPartyId,
+			extensionInDays = extensionInDays
+		).successBody()
+	}
+
+	override suspend fun getCalendarItemsOccupancyByPeriodAndAgendaId(
+		startDate: Long,
+		endDate: Long,
+		agendaId: String,
+		extensionInDays: Int?
+	): List<CalendarItemOccupancy> = doGetCalendarItemsOccupancyByPeriodAndAgendaId(
+		groupId = null,
+		startDate = startDate,
+		endDate = endDate,
+		agendaId = agendaId,
+		extensionInDays = extensionInDays,
+	)
+
+	private suspend fun doGetCalendarItemsOccupancyByPeriodAndAgendaId(
+		groupId: String?,
+		startDate: Long,
+		endDate: Long,
+		agendaId: String,
+		extensionInDays: Int? = null,
+	): List<CalendarItemOccupancy> = if (groupId == null) {
+		rawApi.getCalendarItemsOccupancyByPeriodAndAgendaId(
+			startDate = startDate,
+			endDate = endDate,
+			agendaId = agendaId,
+			extensionInDays = extensionInDays
+		).successBody()
+	} else {
+		rawApi.getCalendarItemsOccupancyByPeriodAndAgendaIdInGroup(
+			groupId = groupId,
+			startDate = startDate,
+			endDate = endDate,
+			agendaId = agendaId,
+			extensionInDays = extensionInDays
+		).successBody()
+	}
 
 	override suspend fun subscribeToEvents(
 		events: Set<SubscriptionEventType>,

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/model/embed/Medication.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/model/embed/Medication.kt
@@ -23,90 +23,22 @@ data class Medication(
 	 *  The expiration date of the medication. Format: yyyyMMdd
 	 */
 	public val expirationDate: Long? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val instructionForPatient: String? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val instructionForReimbursement: String? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val commentForDelivery: String? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val drugRoute: String? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val temporality: String? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val frequency: CodeStub? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val reimbursementReason: CodeStub? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val substitutionAllowed: Boolean? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val beginMoment: Long? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val endMoment: Long? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val deliveryMoment: Long? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val endExecutionMoment: Long? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val duration: Duration? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val renewal: Renewal? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val knownUsage: Boolean? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val regimen: List<RegimenItem>? = null,
-	/**
-	 * The expiration date of the medication. Format: yyyyMMdd
-	 * /
-	 */
 	public val posology: String? = null,
 	public val stockLocation: DecryptedAddress? = null,
 ) {


### PR DESCRIPTION
## Summary
- **Fixes a doc bug in `Medication.kt`**: the automated "Updated models and APIs" sync (90efc3d5, 2026-06-26) gave `instructionForPatient`, `drugRoute`, `temporality`, `frequency`, and 12 other fields the exact same "expiration date of the medication" KDoc as `expirationDate`, plus a stray `* /` line. Verified the true source (`kraken-common`'s `Medication`/`MedicationDto`) has no doc comment on any of these fields — this is a bug in the `sdk-codegen` generation pipeline, not a copy-paste error in this repo. This is a stopgap fix: since the file is bot-regenerated, it may get overwritten by the next sync unless the underlying `sdk-codegen` bug is fixed too (flagging separately).
- **Exposes `CalendarItem` occupancy/heatmap methods on the full API**: `getCalendarItemsOccupancyByPeriodForSelf/ForHealthcareParty/AndAgendaId` (5e84b2c2) were added only to `CalendarItemBasicApi` (backing `CardinalBaseSdk`). They're now also on `CalendarItemApi`/`CalendarItemInGroupApi` (and therefore `CardinalSdk`), reusing the same raw dispatch already shared between the Basic and full API impls via `RawCalendarItemApi` — no new backend surface needed.

## Test plan
- [x] `./gradlew :cardinal-sdk:compileKotlinJvm` — compiles clean
- [ ] Manual smoke test of `sdk.calendarItem.getCalendarItemsOccupancyByPeriodForSelf(...)` against a live backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)