### PR TITLE
2.10.2

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AccessLogApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AccessLogApiImpl.kt
@@ -95,9 +95,9 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return (
 			if (groupId == null) {
-				rawApi.createAccessLog(encrypted)
+				rawApi.createAccessLog(accessLogDto = encrypted)
 			} else {
-				rawApi.createAccessLogInGroup(groupId, encrypted)
+				rawApi.createAccessLogInGroup(groupId = groupId, accessLogDto = encrypted)
 			}
 		).successBody().let {
 			maybeDecrypt(groupId, it)
@@ -107,9 +107,9 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 	protected suspend fun doCreateAccessLogs(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { accessLogs ->
 		val encrypted = validateAndMaybeEncrypt(entitiesGroupId = groupId, entities = accessLogs)
 		if (groupId == null) {
-			rawApi.createAccessLogs(encrypted)
+			rawApi.createAccessLogs(accessLogDtos = encrypted)
 		} else {
-			rawApi.createAccessLogsInGroup(groupId, encrypted)
+			rawApi.createAccessLogsInGroup(groupId = groupId, accessLogsDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -119,8 +119,8 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return (
-			if (groupId == null) rawApi.modifyAccessLog(encrypted)
-			else rawApi.modifyAccessLogInGroup(groupId, encrypted)
+			if (groupId == null) rawApi.modifyAccessLog(accessLogDto = encrypted)
+			else rawApi.modifyAccessLogInGroup(groupId = groupId, accessLogDto = encrypted)
 		).successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -129,8 +129,8 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 	protected suspend fun doModifyAccessLogs(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { accessLogs ->
 		val encrypted = validateAndMaybeEncrypt(groupId, accessLogs)
 		return (
-			if (groupId == null) rawApi.modifyAccessLogs(encrypted)
-			else rawApi.modifyAccessLogsInGroup(groupId, encrypted)
+			if (groupId == null) rawApi.modifyAccessLogs(accessLogDtos = encrypted)
+			else rawApi.modifyAccessLogsInGroup(groupId = groupId, accessLogsDto = encrypted)
 		).successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -139,7 +139,7 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 	protected suspend fun doGetAccessLog(groupId: String?, entityId: String): E? =
 		(
 			if (groupId == null)
-				rawApi.getAccessLog(entityId)
+				rawApi.getAccessLog(accessLogId = entityId)
 			else
 				rawApi.getAccessLogInGroup(groupId = groupId, accessLogId = entityId)
 		).successBodyOrNull404()?.let {
@@ -150,9 +150,9 @@ private abstract class AbstractAccessLogBasicFlavouredApi<E : AccessLog>(
 		maybeDecrypt(
 			groupId,
 			if (groupId == null)
-				rawApi.getAccessLogByIds(ListOfIds(ids)).successBody()
+				rawApi.getAccessLogByIds(accessLogIds = ListOfIds(ids)).successBody()
 			else
-				rawApi.getAccessLogsInGroup(groupId, ListOfIds(ids)).successBody()
+				rawApi.getAccessLogsInGroup(groupId = groupId, accessLogIds = ListOfIds(ids)).successBody()
 		)
 	}
 
@@ -174,10 +174,13 @@ private class AccessLogBasicFlavouredApiImpl<E : AccessLog>(
 	}
 
 	override suspend fun undeleteAccessLogById(id: String, rev: String): E =
-		rawApi.undeleteAccessLog(id, rev).successBodyOrThrowRevisionConflict().let { maybeDecrypt(entitiesGroupId = null, entity = it) }
+		rawApi.undeleteAccessLog(
+			accessLogId = id,
+			rev = rev,
+		).successBodyOrThrowRevisionConflict().let { maybeDecrypt(entitiesGroupId = null, entity = it) }
 
 	override suspend fun undeleteAccessLogsByIds(entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
-		rawApi.undeleteAccessLogs(ListOfIdsAndRev(ids = ids)).successBody().let {
+		rawApi.undeleteAccessLogs(accessLogIds = ListOfIdsAndRev(ids = ids)).successBody().let {
 			maybeDecrypt(entitiesGroupId = null, entities = it)
 		}
 	}
@@ -214,7 +217,7 @@ private class AccessLogBasicFlavouredInGroupApiImpl<E : AccessLog>(
 	}
 
 	override suspend fun undeleteAccessLogById(entityId: GroupScoped<StoredDocumentIdentifier>): GroupScoped<E> =
-		rawApi.undeleteAccessLogInGroup(entityId.groupId, entityId.entity.id, entityId.entity.rev)
+		rawApi.undeleteAccessLogInGroup(groupId = entityId.groupId, accessLogId = entityId.entity.id, rev = entityId.entity.rev)
 			.successBodyOrThrowRevisionConflict()
 			.let { GroupScoped(entity = maybeDecrypt(entitiesGroupId = entityId.groupId, entity = it), groupId = entityId.groupId) }
 
@@ -273,9 +276,9 @@ private abstract class AbstractAccessLogFlavouredApi<E : AccessLog>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -287,7 +290,7 @@ private abstract class AbstractAccessLogFlavouredApi<E : AccessLog>(
 	): PaginatedListIterator<T> =
 		IdsPageIterator(
 			rawApi.matchAccessLogsBy(
-				mapAccessLogFilterOptions(
+				filter = mapAccessLogFilterOptions(
 					filter,
 					config,
 					groupId
@@ -373,17 +376,17 @@ private abstract class AbstractAccessLogBasicFlavourless(
 	protected suspend fun doDeleteAccessLogById(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		(
 			if (groupId == null)
-				rawApi.deleteAccessLog(entityId, rev)
+				rawApi.deleteAccessLog(accessLogId = entityId, rev = rev)
 			else
-				rawApi.deleteAccessLogInGroup(groupId, entityId, rev)
+				rawApi.deleteAccessLogInGroup(groupId = groupId, accessLogId = entityId, rev = rev)
 		).successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteAccessLogsByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteAccessLogsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteAccessLogsWithRev(accessLogIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteAccessLogsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteAccessLogsInGroup(groupId = groupId, accessLogIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
@@ -399,9 +402,9 @@ private abstract class AbstractAccessLogBasicFlavourless(
 	protected suspend fun doPurgeAccessLogsByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeAccessLogs(ListOfIdsAndRev(ids))
+				rawApi.purgeAccessLogs(accessLogIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeAccessLogsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeAccessLogsInGroup(groupId = groupId, accessLogIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }
@@ -646,7 +649,7 @@ private class AccessLogApiImpl(
 	private suspend fun doMatchAccessLogsBy(groupId: String?, filter: FilterOptions<AccessLog>): List<String> =
 		if (groupId == null) {
 			rawApi.matchAccessLogsBy(
-				mapAccessLogFilterOptions(
+				filter = mapAccessLogFilterOptions(
 					filter,
 					config,
 					groupId
@@ -654,12 +657,12 @@ private class AccessLogApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchAccessLogsInGroupBy(
-				groupId = groupId,
 				filter = mapAccessLogFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 }
@@ -716,7 +719,7 @@ private class AccessLogBasicApiImpl(
 	private suspend fun doMatchAccessLogsBy(groupId: String?, filter: BaseFilterOptions<AccessLog>): List<String> =
 		if (groupId == null) {
 			rawApi.matchAccessLogsBy(
-				mapAccessLogFilterOptions(
+				filter = mapAccessLogFilterOptions(
 					filter,
 					config,
 					groupId
@@ -724,12 +727,12 @@ private class AccessLogBasicApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchAccessLogsInGroupBy(
-				groupId = groupId,
 				filter = mapAccessLogFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AgendaApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AgendaApiImpl.kt
@@ -28,32 +28,32 @@ internal abstract class AbstractAgendaApi(
 	protected suspend fun doCreateAgenda(groupId: String?, agenda: Agenda): Agenda {
 		requireIsValidForCreation(agenda)
 		return if (groupId == null) {
-			rawApi.createAgenda(agenda)
+			rawApi.createAgenda(agendaDto = agenda)
 		} else {
-			rawApi.createAgendaInGroup(groupId, agenda)
+			rawApi.createAgendaInGroup(groupId = groupId, agendaDto = agenda)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateAgendas(groupId: String?, entities: List<Agenda>): List<Agenda> = skipRequestOnEmptyList(entities) { agendas ->
 		requireIsValidForCreation(agendas)
 		return if (groupId == null) {
-			rawApi.createAgendas(entities)
+			rawApi.createAgendas(agendasDto = entities)
 		} else {
-			rawApi.createAgendasInGroup(groupId, agendas)
+			rawApi.createAgendasInGroup(groupId = groupId, agendaDtos = agendas)
 		}.successBody()
 	}
 
 	protected suspend fun doDeleteAgendaById(groupId: String?, agendaId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteAgenda(agendaId, rev)
+			rawApi.deleteAgenda(agendaId = agendaId, rev = rev)
 		} else {
-			rawApi.deleteAgendaInGroup(groupId, agendaId, rev)
+			rawApi.deleteAgendaInGroup(groupId = groupId, agendaId = agendaId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteAgendasByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { agendaIds ->
 			if (groupId == null) {
-				rawApi.deleteAgendasWithRev(ListOfIdsAndRev(agendaIds))
+				rawApi.deleteAgendasWithRev(agendaIds = ListOfIdsAndRev(agendaIds))
 			} else {
 				rawApi.deleteAgendasInGroup(groupId = groupId, agendaIdsAndRevs = ListOfIdsAndRev(agendaIds))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
@@ -61,16 +61,16 @@ internal abstract class AbstractAgendaApi(
 
 	protected suspend fun doPurgeAgendaById(groupId: String?, agendaId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeAgenda(agendaId, rev)
+			rawApi.purgeAgenda(agendaId = agendaId, rev = rev)
 		} else {
-			rawApi.purgeAgendaInGroup(groupId, agendaId, rev)
+			rawApi.purgeAgendaInGroup(groupId = groupId, agendaId = agendaId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeAgendasByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { agendaIds ->
 			if (groupId == null) {
-				rawApi.purgeAgendas(ListOfIdsAndRev(agendaIds))
+				rawApi.purgeAgendas(agendaIds = ListOfIdsAndRev(agendaIds))
 			} else {
 				rawApi.purgeAgendasInGroup(groupId = groupId, agendaIdsAndRevs = ListOfIdsAndRev(agendaIds))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
@@ -78,15 +78,15 @@ internal abstract class AbstractAgendaApi(
 
 	protected suspend fun doUndeleteAgendaById(groupId: String?, agendaId: String, rev: String): Agenda =
 		if (groupId == null) {
-			rawApi.undeleteAgenda(agendaId, rev)
+			rawApi.undeleteAgenda(agendaId = agendaId, rev = rev)
 		} else {
-			rawApi.undeleteAgendaInGroup(groupId, agendaId, rev)
+			rawApi.undeleteAgendaInGroup(groupId = groupId, agendaId = agendaId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteAgendasByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<Agenda> =
 		skipRequestOnEmptyList(entityIds) { agendaIds ->
 			if (groupId == null) {
-				rawApi.undeleteAgendas(ListOfIdsAndRev(agendaIds))
+				rawApi.undeleteAgendas(agendaIds = ListOfIdsAndRev(agendaIds))
 			} else {
 				rawApi.undeleteAgendasInGroup(groupId = groupId, agendaIdsAndRevs = ListOfIdsAndRev(agendaIds))
 			}.successBody()
@@ -95,9 +95,9 @@ internal abstract class AbstractAgendaApi(
 	protected suspend fun doGetAgendasByIds(groupId: String?, entityIds: List<String>): List<Agenda> =
 		skipRequestOnEmptyList(entityIds) { agendaIds ->
 			if (groupId == null) {
-				rawApi.getAgendasByIds(ListOfIds(agendaIds))
+				rawApi.getAgendasByIds(agendaIds = ListOfIds(agendaIds))
 			} else {
-				rawApi.getAgendasInGroup(groupId = groupId, ListOfIds(agendaIds))
+				rawApi.getAgendasInGroup(groupId = groupId, agendaIds = ListOfIds(agendaIds))
 			}.successBody()
 		}
 
@@ -111,24 +111,24 @@ internal abstract class AbstractAgendaApi(
 	protected suspend fun doModifyAgenda(groupId: String?, agenda: Agenda): Agenda {
 		requireIsValidForModification(agenda)
 		return if (groupId == null) {
-			rawApi.modifyAgenda(agenda)
+			rawApi.modifyAgenda(agendaDto = agenda)
 		} else {
-			rawApi.modifyAgendaInGroup(groupId, agenda)
+			rawApi.modifyAgendaInGroup(groupId = groupId, agendaDto = agenda)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyAgendas(groupId: String?, agendas: List<Agenda>): List<Agenda> = skipRequestOnEmptyList(agendas) { entities ->
 		requireIsValidForModification(entities)
 		return if (groupId == null) {
-			rawApi.modifyAgendas(entities)
+			rawApi.modifyAgendas(agendaDtos = entities)
 		} else {
-			rawApi.modifyAgendasInGroup(groupId, entities)
+			rawApi.modifyAgendasInGroup(groupId = groupId, agendaDtos = entities)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doMatchAgendasBy(groupId: String?, filter: BaseFilterOptions<Agenda>): List<String> =
 		if (groupId == null) {
-			rawApi.matchAgendasBy(mapAgendaFilterOptions(filter, config))
+			rawApi.matchAgendasBy(filter = mapAgendaFilterOptions(filter, config))
 		} else {
 			rawApi.matchAgendasInGroupBy(groupId = groupId, filter = mapAgendaFilterOptions(filter, config, groupId))
 		}.successBody()

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AnonymousAgendaApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AnonymousAgendaApiImpl.kt
@@ -14,9 +14,9 @@ class AnonymousAgendaApiImpl(
 		propertyId: String,
 		propertyValue: String,
 	): PublicAgendasAndCalendarItemTypes = raw.listAnonymousAgendaAndAppointmentTypes(
-		groupId,
-		propertyId,
-		propertyValue
+		groupId = groupId,
+		propertyId = propertyId,
+		propertyValue = propertyValue
 	).successBody()
 
 	override suspend fun listAnonymousAvailabilities(
@@ -27,11 +27,11 @@ class AnonymousAgendaApiImpl(
 		endDate: Long,
 		limit: Int?
 	): List<Long> = raw.listAnonymousAvailabilities(
-		groupId,
-		agendaId,
-		calendarItemTypeId,
-		startDate,
-		endDate,
-		limit,
+		groupId = groupId,
+		agendaId = agendaId,
+		calendarItemTypeId = calendarItemTypeId,
+		startDate = startDate,
+		endDate = endDate,
+		limit = limit,
 	).successBody()
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AnonymousHealthcarePartyApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AnonymousHealthcarePartyApiImpl.kt
@@ -11,5 +11,5 @@ class AnonymousHealthcarePartyApiImpl(
 ): AnonymousHealthcarePartyApi {
 	override suspend fun getPublicHealthcarePartiesInGroup(
 		groupId: String
-	): List<HealthcareParty> = raw.listPublicHealthcarePartiesInGroup(groupId).successBody()
+	): List<HealthcareParty> = raw.listPublicHealthcarePartiesInGroup(groupId = groupId).successBody()
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
@@ -106,9 +106,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createCalendarItem(encrypted)
+			rawApi.createCalendarItem(calendarItemDto = encrypted)
 		} else {
-			rawApi.createCalendarItemInGroup(groupId, encrypted)
+			rawApi.createCalendarItemInGroup(groupId = groupId, calendarItemDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -117,9 +117,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 	protected suspend fun doCreateCalendarItems(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { calendarItems ->
 		val encrypted = validateAndMaybeEncrypt(groupId, calendarItems)
 		if (groupId == null) {
-			rawApi.createCalendarItems(encrypted)
+			rawApi.createCalendarItems(calendarItemDtos = encrypted)
 		} else {
-			rawApi.createCalendarItemsInGroup(groupId, encrypted)
+			rawApi.createCalendarItemsInGroup(groupId = groupId, calendarItemDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -127,7 +127,7 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 
 	protected suspend fun doUndeleteCalendarItemById(groupId: String?, id: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteCalendarItem(id, rev)
+			rawApi.undeleteCalendarItem(calendarItemId = id, rev = rev)
 		} else {
 			rawApi.undeleteCalendarItemInGroup(groupId = groupId, calendarItemId = id, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
@@ -135,9 +135,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 	protected suspend fun doUndeleteCalendarItemsByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteCalendarItems(ListOfIdsAndRev(ids))
+				rawApi.undeleteCalendarItems(calendarItemIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteCalendarItemsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteCalendarItemsInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().let { maybeDecrypt(entitiesGroupId = groupId, entities = it) }
 		}
 
@@ -145,9 +145,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyCalendarItem(encrypted)
+			rawApi.modifyCalendarItem(calendarItemDto = encrypted)
 		} else {
-			rawApi.modifyCalendarItemInGroup(groupId, encrypted)
+			rawApi.modifyCalendarItemInGroup(groupId = groupId, calendarItemDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -159,9 +159,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 	): List<E> = skipRequestOnEmptyList(entities) { calendarItems ->
 		val encrypted = validateAndMaybeEncrypt(groupId, calendarItems)
 		return if (groupId == null) {
-			rawApi.modifyCalendarItems(encrypted)
+			rawApi.modifyCalendarItems(calendarItemDtos = encrypted)
 		} else {
-			rawApi.modifyCalendarItemsInGroup(groupId, encrypted)
+			rawApi.modifyCalendarItemsInGroup(groupId = groupId, calendarItemDtos = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -169,7 +169,7 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 
 	protected suspend fun doGetCalendarItem(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getCalendarItem(entityId)
+			rawApi.getCalendarItem(calendarItemId = entityId)
 		} else {
 			rawApi.getCalendarItemInGroup(groupId = groupId, calendarItemId = entityId)
 		}.successBodyOrNull404()?.let {
@@ -178,9 +178,9 @@ private abstract class AbstractCalendarItemBasicFlavouredApi<E : CalendarItem>(
 
 	suspend fun doGetCalendarItems(groupId: String?, entityIds: List<String>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getCalendarItemsWithIds(ListOfIds(ids))
+			rawApi.getCalendarItemsWithIds(calendarItemIds = ListOfIds(ids))
 		} else {
-			rawApi.getCalendarItemsInGroup(groupId, ListOfIds(ids))
+			rawApi.getCalendarItemsInGroup(groupId = groupId, calendarItemIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 }
@@ -205,7 +205,7 @@ private class CalendarItemBasicFlavouredApiImpl<E : CalendarItem>(
 		val encrypted = validateAndMaybeEncrypt(null, entity)
 		return maybeDecrypt(
 			null,
-			rawApi.safeBook(encrypted).successBody(MissingAvailabilityException)
+			rawApi.safeBook(calendarItemDto = encrypted).successBody(MissingAvailabilityException)
 		)
 	}
 
@@ -300,9 +300,9 @@ private abstract class AbstractCalendarItemFlavouredApi<E : CalendarItem>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -314,7 +314,7 @@ private abstract class AbstractCalendarItemFlavouredApi<E : CalendarItem>(
 	): PaginatedListIterator<T> =
 		IdsPageIterator(
 			rawApi.matchCalendarItemsBy(
-				mapCalendarItemFilterOptions(
+				filter = mapCalendarItemFilterOptions(
 					filter,
 					config,
 					groupId
@@ -373,8 +373,8 @@ private class CalendarItemFlavouredApiImpl<E : CalendarItem>(
 			),
 			EntityWithEncryptionMetadataTypeName.CalendarItem,
 			true,
-			{ rawApi.getCalendarItem(it).successBody() },
-			{ rawApi.bulkShare(it).successBody() }
+			{ rawApi.getCalendarItem(calendarItemId = it).successBody() },
+			{ rawApi.bulkShare(request = it).successBody() }
 		)
 		if(shareResult.updatedEntities.isEmpty() || shareResult.updatedEntities.first().id != calendarItem.id) {
 			val errorsForEntity = shareResult.updateErrors.filter { it.entityId == calendarItem.id }
@@ -387,7 +387,7 @@ private class CalendarItemFlavouredApiImpl<E : CalendarItem>(
 		return maybeDecrypt(
 			null,
 			rawApi.modifyCalendarItem(
-				(shareResult.updatedEntities.first() as EncryptedCalendarItem).copy(secretForeignKeys = secretForeignKeys)
+				calendarItemDto = (shareResult.updatedEntities.first() as EncryptedCalendarItem).copy(secretForeignKeys = secretForeignKeys)
 			).successBody()
 		)
 	}
@@ -447,34 +447,34 @@ private abstract class AbstractCalendarItemBasicFlavourless(
 
 	protected suspend fun doDeleteCalendarItemById(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteCalendarItem(entityId, rev)
+			rawApi.deleteCalendarItem(calendarItemId = entityId, rev = rev)
 		} else {
-			rawApi.deleteCalendarItemInGroup(groupId, entityId, rev)
+			rawApi.deleteCalendarItemInGroup(groupId = groupId, calendarItemId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteCalendarItemsByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteCalendarItemsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteCalendarItemsWithRev(calendarItemIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteCalendarItemsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteCalendarItemsInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeCalendarItemById(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeCalendarItem(entityId, rev)
+			rawApi.purgeCalendarItem(calendarItemId = entityId, rev = rev)
 		} else {
-			rawApi.purgeCalendarItemInGroup(groupId, entityId, rev)
+			rawApi.purgeCalendarItemInGroup(groupId = groupId, calendarItemId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeCalendarItemsByIds(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeCalendarItems(ListOfIdsAndRev(ids))
+				rawApi.purgeCalendarItems(calendarItemIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeCalendarItemsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeCalendarItemsInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }
@@ -774,7 +774,7 @@ private class CalendarItemApiImpl(
 	private suspend fun doMatchCalendarItemsBy(groupId: String?, filter: FilterOptions<CalendarItem>): List<String> =
 		if (groupId == null) {
 			rawApi.matchCalendarItemsBy(
-				mapCalendarItemFilterOptions(
+				filter = mapCalendarItemFilterOptions(
 					filter,
 					config,
 					groupId
@@ -782,12 +782,12 @@ private class CalendarItemApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchCalendarItemsInGroupBy(
-				groupId = groupId,
 				filter = mapCalendarItemFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 
@@ -1026,7 +1026,7 @@ private class CalendarItemBasicApiImpl(
 	private suspend fun doMatchCalendarItemsBy(groupId: String?, filter: BaseFilterOptions<CalendarItem>): List<String> =
 		if (groupId == null) {
 			rawApi.matchCalendarItemsBy(
-				mapCalendarItemFilterOptions(
+				filter = mapCalendarItemFilterOptions(
 					filter,
 					config,
 					groupId
@@ -1034,12 +1034,12 @@ private class CalendarItemBasicApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchCalendarItemsInGroupBy(
-				groupId = groupId,
 				filter = mapCalendarItemFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemTypeApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemTypeApiImpl.kt
@@ -21,101 +21,101 @@ internal abstract class AbstractCalendarItemTypeApi(
 	protected suspend fun doCreateCalendarItemType(groupId: String?, entity: CalendarItemType): CalendarItemType {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createCalendarItemType(entity)
+			rawApi.createCalendarItemType(calendarItemTypeDto = entity)
 		} else {
-			rawApi.createCalendarItemTypeInGroup(groupId, entity)
+			rawApi.createCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeDto = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateCalendarItemTypes(groupId: String?, entities: List<CalendarItemType>): List<CalendarItemType> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.createCalendarItemTypes(calendarItemTypes)
+				rawApi.createCalendarItemTypes(calendarItemTypeDtos = calendarItemTypes)
 			} else {
-				rawApi.createCalendarItemTypesInGroup(groupId, calendarItemTypes)
+				rawApi.createCalendarItemTypesInGroup(groupId = groupId, calendarItemTypeDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doGetCalendarItemType(groupId: String?, entityId: String): CalendarItemType? =
 		if (groupId == null) {
-			rawApi.getCalendarItemType(entityId)
+			rawApi.getCalendarItemType(calendarItemTypeId = entityId)
 		} else {
-			rawApi.getCalendarItemTypeInGroup(groupId, entityId)
+			rawApi.getCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetCalendarItemTypes(groupId: String?, entityIds: List<String>): List<CalendarItemType> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getCalendarItemTypesByIds(ListOfIds(ids))
+				rawApi.getCalendarItemTypesByIds(calendarItemTypeIds = ListOfIds(ids))
 			} else {
-				rawApi.getCalendarItemTypesInGroup(groupId, ListOfIds(ids))
+				rawApi.getCalendarItemTypesInGroup(groupId = groupId, calendarItemTypeIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyCalendarItemType(groupId: String?, entity: CalendarItemType): CalendarItemType {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyCalendarItemType(entity)
+			rawApi.modifyCalendarItemType(calendarItemTypeDto = entity)
 		} else {
-			rawApi.modifyCalendarItemTypeInGroup(groupId, entity)
+			rawApi.modifyCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeDto = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyCalendarItemTypes(groupId: String?, entities: List<CalendarItemType>): List<CalendarItemType> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.modifyCalendarItemTypes(calendarItemTypes)
+				rawApi.modifyCalendarItemTypes(calendarItemTypeDtos = calendarItemTypes)
 			} else {
-				rawApi.modifyCalendarItemTypesInGroup(groupId, calendarItemTypes)
+				rawApi.modifyCalendarItemTypesInGroup(groupId = groupId, calendarItemTypeDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteCalendarItemType(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteCalendarItemType(entityId, rev)
+			rawApi.deleteCalendarItemType(calendarItemTypeId = entityId, rev = rev)
 		} else {
-			rawApi.deleteCalendarItemTypeInGroup(groupId, entityId, rev)
+			rawApi.deleteCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteCalendarItemTypes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteCalendarItemTypesWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteCalendarItemTypesWithRev(calendarItemTypeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteCalendarItemTypesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteCalendarItemTypesInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteCalendarItemType(groupId: String?, entityId: String, rev: String): CalendarItemType =
 		if (groupId == null) {
-			rawApi.undeleteCalendarItemType(entityId, rev)
+			rawApi.undeleteCalendarItemType(calendarItemTypeId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteCalendarItemTypeInGroup(groupId, entityId, rev)
+			rawApi.undeleteCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteCalendarItemTypes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<CalendarItemType> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteCalendarItemTypes(ListOfIdsAndRev(ids))
+				rawApi.undeleteCalendarItemTypes(calendarItemTypeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteCalendarItemTypesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteCalendarItemTypesInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeCalendarItemType(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeCalendarItemType(entityId, rev)
+			rawApi.purgeCalendarItemType(calendarItemTypeId = entityId, rev = rev)
 		} else {
-			rawApi.purgeCalendarItemTypeInGroup(groupId, entityId, rev)
+			rawApi.purgeCalendarItemTypeInGroup(groupId = groupId, calendarItemTypeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeCalendarItemTypes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeCalendarItemTypesWithRev(ListOfIdsAndRev(ids))
+				rawApi.purgeCalendarItemTypesWithRev(calendarItemTypeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeCalendarItemTypesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeCalendarItemTypesInGroup(groupId = groupId, calendarItemIdsAndRevs = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CardinalMaintenanceTaskApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CardinalMaintenanceTaskApiImpl.kt
@@ -138,9 +138,9 @@ class CardinalMaintenanceTaskApiImpl(
 	): Set<String> {
 		val self = dataOwnerApi.getCurrentDataOwnerId()
 		val candidatesForExchangeData = exchangeDataManager.base.raw.getParticipantCounterparts(
-			self,
-			requestToOwnerTypes.joinToString(","),
-			key.fingerprintV2().s
+			dataOwnerId = self,
+			counterpartsTypes = requestToOwnerTypes.joinToString(","),
+			ignoreOnEntryForFingerprint = key.fingerprintV2().s
 		).successBody().toSet()
 		val fingerprintV1 = key.fingerprintV1()
 		val exchangeKeysInfo = baseExchangeKeysManager.getAllExchangeKeysWith(self, requestToOwnerTypes)

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ClassificationApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ClassificationApiImpl.kt
@@ -46,18 +46,19 @@ private abstract class AbstractClassificationBasicFlavouredApi<E : Classificatio
 	override suspend fun createClassification(entity: E): E {
 		require(entity.securityMetadata != null) { "Entity must have security metadata initialized. Make sure to use the `withEncryptionMetadata` method." }
 		return rawApi.createClassification(
-			validateAndMaybeEncrypt(null, entity),
+			c = validateAndMaybeEncrypt(null, entity),
 		).successBody().let {
 			maybeDecrypt(null, it)
 		}
 	}
 
 	override suspend fun modifyClassification(entity: E): E =
-		rawApi.modifyClassification(validateAndMaybeEncrypt(null, entity)).successBodyOrThrowRevisionConflict().let { maybeDecrypt(null, it) }
-
+		rawApi.modifyClassification(classificationDto = validateAndMaybeEncrypt(null, entity))
+			.successBodyOrThrowRevisionConflict()
+			.let { maybeDecrypt(null, it) }
 
 	override suspend fun getClassification(entityId: String): E? =
-		rawApi.getClassification(entityId).successBodyOrNull404()
+		rawApi.getClassification(classificationId = entityId).successBodyOrNull404()
 			?.let { maybeDecrypt(null, it) }
 
 	override suspend fun getClassifications(entityIds: List<String>): List<E> =
@@ -84,7 +85,7 @@ private abstract class AbstractClassificationFlavouredApi<E : Classification>(
 			delegates.keyAsLocalDataOwnerReferences(),
 			true,
 			{ getClassification(it) ?: throw NotFoundException("Classification $it not found") },
-			{ maybeDecrypt(null, rawApi.bulkShare(it).successBody()) }
+			{ maybeDecrypt(null, rawApi.bulkShare(request = it).successBody()) }
 		).updatedEntityOrThrow()
 
 	@Deprecated("Use filter instead")
@@ -109,7 +110,7 @@ private abstract class AbstractClassificationFlavouredApi<E : Classification>(
 				).toList())
 		).successBody()
 	) { ids ->
-		maybeDecrypt(rawApi.getClassifications(ListOfIds(ids)).successBody())
+		maybeDecrypt(rawApi.getClassifications(classificationIds = ListOfIds(ids)).successBody())
 	}
 
 	override suspend fun filterClassificationsBySorted(filter: SortableFilterOptions<Classification>): PaginatedListIterator<E> =
@@ -118,7 +119,7 @@ private abstract class AbstractClassificationFlavouredApi<E : Classification>(
 	override suspend fun filterClassificationsBy(filter: FilterOptions<Classification>): PaginatedListIterator<E> =
 		IdsPageIterator(
 			rawApi.matchClassificationBy(
-				mapClassificationFilterOptions(
+				filter = mapClassificationFilterOptions(
 					filter,
 					config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
 					config.crypto.entity
@@ -131,9 +132,10 @@ private abstract class AbstractClassificationFlavouredApi<E : Classification>(
 @InternalIcureApi
 private class AbstractClassificationBasicFlavourlessApi(val rawApi: RawClassificationApi) :
 	ClassificationBasicFlavourlessApi {
-	override suspend fun deleteClassification(entityId: String) = rawApi.deleteClassification(entityId).successBody()
+	override suspend fun deleteClassification(entityId: String) =
+		rawApi.deleteClassification(classificationId = entityId).successBody()
 	override suspend fun deleteClassifications(entityIds: List<String>) = rawApi.deleteClassifications(
-		ListOfIds(
+		classificationIds = ListOfIds(
 			entityIds
 		)
 	).successBody()
@@ -231,21 +233,21 @@ internal class ClassificationApiImpl(
 		alternateRootDelegateId: String?,
 	): DecryptedClassification =
 		crypto.entity.entityWithInitializedEncryptedMetadata(
-            null,
-            (base ?: DecryptedClassification(crypto.primitives.strongRandom.randomUUID())).copy(
-                created = base?.created ?: currentEpochMs(),
-                modified = base?.modified ?: currentEpochMs(),
-                responsible = base?.responsible ?: user?.takeIf { config.autofillAuthor }?.dataOwnerId,
-                author = base?.author ?: user?.id?.takeIf { config.autofillAuthor },
-            ),
-            EntityWithEncryptionMetadataTypeName.Classification,
-            OwningEntityDetails(
-                null,
-                patient.id,
-                crypto.entity.resolveSecretIdOption(null, patient, EntityWithEncryptionMetadataTypeName.Patient, secretId),
-            ),
-            initializeEncryptionKey = true,
-            autoDelegations = (delegates + user?.autoDelegationsFor(DelegationTag.MedicalInformation).orEmpty()).keyAsLocalDataOwnerReferences(),
+			null,
+			(base ?: DecryptedClassification(crypto.primitives.strongRandom.randomUUID())).copy(
+				created = base?.created ?: currentEpochMs(),
+				modified = base?.modified ?: currentEpochMs(),
+				responsible = base?.responsible ?: user?.takeIf { config.autofillAuthor }?.dataOwnerId,
+				author = base?.author ?: user?.id?.takeIf { config.autofillAuthor },
+			),
+			EntityWithEncryptionMetadataTypeName.Classification,
+			OwningEntityDetails(
+				null,
+				patient.id,
+				crypto.entity.resolveSecretIdOption(null, patient, EntityWithEncryptionMetadataTypeName.Patient, secretId),
+			),
+			initializeEncryptionKey = true,
+			autoDelegations = (delegates + user?.autoDelegationsFor(DelegationTag.MedicalInformation).orEmpty()).keyAsLocalDataOwnerReferences(),
 			alternateRootDataOwnerReference = alternateRootDelegateId?.let { EntityReferenceInGroup(it, null) },
 		).updatedEntity
 
@@ -277,7 +279,7 @@ internal class ClassificationApiImpl(
 
 	override suspend fun matchClassificationsBy(filter: FilterOptions<Classification>): List<String> =
 		rawApi.matchClassificationBy(
-			mapClassificationFilterOptions(
+			filter = mapClassificationFilterOptions(
 				filter,
 				config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
 				config.crypto.entity
@@ -307,7 +309,7 @@ internal class ClassificationBasicApiImpl(
 }, ClassificationBasicFlavourlessApi by AbstractClassificationBasicFlavourlessApi(rawApi) {
 	override suspend fun matchClassificationsBy(filter: BaseFilterOptions<Classification>): List<String> =
 		rawApi.matchClassificationBy(
-			mapClassificationFilterOptions(
+			filter = mapClassificationFilterOptions(
 				filter,
 				null,
 				null

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CodeApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CodeApiImpl.kt
@@ -29,107 +29,107 @@ internal abstract class AbstractCodeApi(
 	protected suspend fun doCreateCode(groupId: String?, entity: Code): Code {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createCode(entity)
+			rawApi.createCode(c = entity)
 		} else {
-			rawApi.createCodeInGroup(groupId, entity)
+			rawApi.createCodeInGroup(groupId = groupId, c = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateCodes(groupId: String?, entities: List<Code>): List<Code> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.createCodes(calendarItemTypes)
+				rawApi.createCodes(codeBatch = calendarItemTypes)
 			} else {
-				rawApi.createCodesInGroup(groupId, calendarItemTypes)
+				rawApi.createCodesInGroup(groupId = groupId, codeBatch = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doGetCode(groupId: String?, entityId: String): Code? =
 		if (groupId == null) {
-			rawApi.getCode(entityId)
+			rawApi.getCode(codeId = entityId)
 		} else {
-			rawApi.getCodeInGroup(groupId, entityId)
+			rawApi.getCodeInGroup(groupId = groupId, codeId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetCodes(groupId: String?, entityIds: List<String>): List<Code> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getCodes(ListOfIds(ids))
+				rawApi.getCodes(codeIds = ListOfIds(ids))
 			} else {
-				rawApi.getCodesInGroup(groupId, ListOfIds(ids))
+				rawApi.getCodesInGroup(groupId = groupId, codeIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyCode(groupId: String?, entity: Code): Code {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyCode(entity)
+			rawApi.modifyCode(codeDto = entity)
 		} else {
-			rawApi.modifyCodeInGroup(groupId, entity)
+			rawApi.modifyCodeInGroup(groupId = groupId, code = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyCodes(groupId: String?, entities: List<Code>): List<Code> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.modifyCodes(calendarItemTypes)
+				rawApi.modifyCodes(codeBatch = calendarItemTypes)
 			} else {
-				rawApi.modifyCodesInGroup(groupId, calendarItemTypes)
+				rawApi.modifyCodesInGroup(groupId = groupId, codeBatch = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteCode(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteCode(entityId, rev)
+			rawApi.deleteCode(codeId = entityId, rev = rev)
 		} else {
-			rawApi.deleteCodeInGroup(groupId, entityId, rev)
+			rawApi.deleteCodeInGroup(groupId = groupId, codeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteCodes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteCodes(ListOfIdsAndRev(ids))
+				rawApi.deleteCodes(codeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteCodesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteCodesInGroup(groupId = groupId, codeIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteCode(groupId: String?, entityId: String, rev: String): Code =
 		if (groupId == null) {
-			rawApi.undeleteCode(entityId, rev)
+			rawApi.undeleteCode(codeId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteCodeInGroup(groupId, entityId, rev)
+			rawApi.undeleteCodeInGroup(groupId = groupId, codeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteCodes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<Code> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteCodes(ListOfIdsAndRev(ids))
+				rawApi.undeleteCodes(codeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteCodesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteCodesInGroup(groupId = groupId, codeIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeCode(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeCode(entityId, rev)
+			rawApi.purgeCode(codeId = entityId, rev = rev)
 		} else {
-			rawApi.purgeCodeInGroup(groupId, entityId, rev)
+			rawApi.purgeCodeInGroup(groupId = groupId, codeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeCodes(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeCodes(ListOfIdsAndRev(ids))
+				rawApi.purgeCodes(codeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeCodesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeCodesInGroup(groupId = groupId, codeIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doMatchCodesBy(groupId: String?, filter: BaseFilterOptions<Code>): List<String> =
 		if (groupId == null) {
-			rawApi.matchCodesBy(mapCodeFilterOptions(filter, config))
+			rawApi.matchCodesBy(filter = mapCodeFilterOptions(filter, config))
 		} else {
 			rawApi.matchCodesBy(groupId = groupId, filter = mapCodeFilterOptions(filter, config, groupId))
 		}.successBody()
@@ -144,28 +144,30 @@ internal class CodeApiImpl(
 
 	override val inGroup = CodeInGroupApiImpl(rawApi, config)
 
-	override suspend fun listCodeTypesBy(region: String?, type: String?): List<String> = rawApi.listCodeTypesBy(region, type).successBody()
+	override suspend fun listCodeTypesBy(region: String?, type: String?): List<String> =
+		rawApi.listCodeTypesBy(region = region, type = type).successBody()
 
-	override suspend fun listTagTypesBy(region: String?, type: String?): List<String> = rawApi.listTagTypesBy(region, type).successBody()
+	override suspend fun listTagTypesBy(region: String?, type: String?): List<String> =
+		rawApi.listTagTypesBy(region = region, type = type).successBody()
 
 	override suspend fun isCodeValid(
 		type: String,
 		code: String,
 		version: String?,
-	): BooleanResponse = rawApi.isCodeValid(type, code, version).successBody()
+	): BooleanResponse = rawApi.isCodeValid(type = type, code = code, version = version).successBody()
 
 	override suspend fun getCodeByRegionLanguageTypeLabel(
 		region: String,
 		label: String,
 		type: String,
 		languages: String?,
-	): Code? = rawApi.getCodeByRegionLanguageTypeLabelOr404(region, label, type, languages).successBodyOrNull404()
+	): Code? = rawApi.getCodeByRegionLanguageTypeLabelOr404(region = region, label = label, type = type, languages = languages).successBodyOrNull404()
 
 	override suspend fun getCodeWithParts(
 		type: String,
 		code: String,
 		version: String,
-	): Code? = rawApi.getCodeWithParts(type, code, version).successBodyOrNull404()
+	): Code? = rawApi.getCodeWithParts(type = type, code = code, version = version).successBodyOrNull404()
 
 	override suspend fun createCode(code: Code): Code = doCreateCode(groupId = null, code)
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ContactApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ContactApiImpl.kt
@@ -360,9 +360,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createContact(encrypted)
+			rawApi.createContact(c = encrypted)
 		} else {
-			rawApi.createContactInGroup(groupId, encrypted)
+			rawApi.createContactInGroup(groupId = groupId, contactDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -371,9 +371,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 	protected suspend fun doCreateContacts(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { contacts ->
 		val encrypted = validateAndMaybeEncrypt(groupId, contacts)
 		if (groupId == null) {
-			rawApi.createContacts(encrypted)
+			rawApi.createContacts(contactDtos = encrypted)
 		} else {
-			rawApi.createContactsInGroup(groupId, encrypted)
+			rawApi.createContactsInGroup(groupId = groupId, contactDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -381,7 +381,7 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 
 	protected suspend fun doUndeleteContact(groupId: String?, id: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteContact(id, rev)
+			rawApi.undeleteContact(contactId = id, rev = rev)
 		} else {
 			rawApi.undeleteContactInGroup(groupId = groupId, contactId = id, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
@@ -389,9 +389,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 	protected suspend fun doUndeleteContacts(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteContacts(ListOfIdsAndRev(ids))
+				rawApi.undeleteContacts(contactIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteContactsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteContactsInGroup(groupId = groupId, contactIds = ListOfIdsAndRev(ids))
 			}.successBody().let { maybeDecrypt(entitiesGroupId = groupId, entities = it) }
 		}
 
@@ -399,9 +399,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyContact(encrypted)
+			rawApi.modifyContact(contactDto = encrypted)
 		} else {
-			rawApi.modifyContactInGroup(groupId, encrypted)
+			rawApi.modifyContactInGroup(groupId = groupId, contactDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -413,9 +413,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 	): List<E> = skipRequestOnEmptyList(entities) { contacts ->
 		val encrypted = validateAndMaybeEncrypt(groupId, contacts)
 		return if (groupId == null) {
-			rawApi.modifyContacts(encrypted)
+			rawApi.modifyContacts(contactDtos = encrypted)
 		} else {
-			rawApi.modifyContactsInGroup(groupId, encrypted)
+			rawApi.modifyContactsInGroup(groupId = groupId, contactDtos = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -423,7 +423,7 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 
 	protected suspend fun doGetContact(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getContact(entityId)
+			rawApi.getContact(contactId = entityId)
 		} else {
 			rawApi.getContactInGroup(groupId = groupId, contactId = entityId)
 		}.successBodyOrNull404()?.let {
@@ -432,15 +432,15 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 
 	suspend fun doGetContacts(groupId: String?, entityIds: List<String>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getContacts(ListOfIds(ids))
+			rawApi.getContacts(contactIds = ListOfIds(ids))
 		} else {
-			rawApi.getContactsInGroup(groupId, ListOfIds(ids))
+			rawApi.getContactsInGroup(groupId = groupId, contactIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doGetService(groupId: String?, entityId: String): S? =
 		if (groupId == null) {
-			rawApi.getService(entityId)
+			rawApi.getService(serviceId = entityId)
 		} else {
 			rawApi.getServiceInGroup(groupId = groupId, serviceId = entityId)
 		}.successBodyOrNull404()?.let {
@@ -449,9 +449,9 @@ private abstract class AbstractContactBasicFlavouredApi<E : Contact, S : Service
 
 	protected suspend fun doGetServices(groupId: String?, entityIds: List<String>): List<S> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getServices(ListOfIds(ids))
+			rawApi.getServices(ids = ListOfIds(ids))
 		} else {
-			rawApi.getServicesInGroup(groupId = groupId, ListOfIds(ids))
+			rawApi.getServicesInGroup(groupId = groupId, ids = ListOfIds(ids))
 		}.successBody().let {
 			maybeDecryptServices(groupId, it)
 		}
@@ -572,9 +572,9 @@ private abstract class AbstractContactFlavouredApi<E : Contact, S : Service>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -586,7 +586,7 @@ private abstract class AbstractContactFlavouredApi<E : Contact, S : Service>(
 	): PaginatedListIterator<T> =
 		IdsPageIterator(
 			rawApi.matchContactsBy(
-				mapContactFilterOptions(
+				filter = mapContactFilterOptions(
 					filter,
 					config,
 					groupId
@@ -625,7 +625,7 @@ private  class ContactFlavouredApiImpl<E : Contact, S : Service>(
 	override suspend fun filterServicesBy(filter: FilterOptions<Service>): PaginatedListIterator<S> =
 		IdsPageIterator(
 			rawApi.matchServicesBy(
-				mapServiceFilterOptions(
+				filter = mapServiceFilterOptions(
 					filterOptions = filter,
 					config = config,
 					requestGroup = null
@@ -677,34 +677,34 @@ private abstract class AbstractContactBasicFlavourless(
 
 	protected suspend fun doDeleteContact(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteContact(entityId, rev)
+			rawApi.deleteContact(contactId = entityId, rev = rev)
 		} else {
-			rawApi.deleteContactInGroup(groupId, entityId, rev)
+			rawApi.deleteContactInGroup(groupId = groupId, contactId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteContacts(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteContactsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteContactsWithRev(contactIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteContactsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteContactsInGroup(groupId = groupId, contactIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeContact(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeContact(entityId, rev)
+			rawApi.purgeContact(contactId = entityId, rev = rev)
 		} else {
-			rawApi.purgeContactInGroup(groupId, entityId, rev)
+			rawApi.purgeContactInGroup(groupId = groupId, contactId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeContacts(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeContacts(ListOfIdsAndRev(ids))
+				rawApi.purgeContacts(contactIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeContactsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeContactsInGroup(groupId = groupId, contactIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
@@ -727,7 +727,7 @@ private class ContactBasicFlavourlessApiImpl(rawApi: RawContactApi) : AbstractCo
 		doPurgeContacts(groupId = null, entityIds = entityIds)
 
 	override suspend fun getServiceCodesOccurrences(codeType: String, minOccurrences: Long): List<LabelledOccurence> {
-		return rawApi.getServiceCodesOccurrences(codeType, minOccurrences).successBody()
+		return rawApi.getServiceCodesOccurrences(codeType = codeType, minOccurrences = minOccurrences).successBody()
 	}
 }
 
@@ -1005,7 +1005,7 @@ private class ContactApiImpl(
 	private suspend fun doMatchContactsBy(groupId: String?, filter: FilterOptions<Contact>): List<String> =
 		if (groupId == null) {
 			rawApi.matchContactsBy(
-				mapContactFilterOptions(
+				filter = mapContactFilterOptions(
 					filter,
 					config,
 					groupId
@@ -1013,12 +1013,12 @@ private class ContactApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchContactsInGroupBy(
-				groupId = groupId,
 				filter = mapContactFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 
@@ -1034,7 +1034,7 @@ private class ContactApiImpl(
 	private suspend fun doMatchServicesBy(groupId: String?, filter: FilterOptions<Service>): List<String> =
 		if (groupId == null) {
 			rawApi.matchServicesBy(
-				mapServiceFilterOptions(
+				filter = mapServiceFilterOptions(
 					filter,
 					config,
 					groupId
@@ -1238,7 +1238,7 @@ private class ContactBasicApiImpl(
 	private suspend fun doMatchContactsBy(groupId: String?, filter: FilterOptions<Contact>): List<String> =
 		if (groupId == null) {
 			rawApi.matchContactsBy(
-				mapContactFilterOptions(
+				filter = mapContactFilterOptions(
 					filter,
 					config,
 					groupId
@@ -1246,12 +1246,12 @@ private class ContactBasicApiImpl(
 			).successBody()
 		} else {
 			rawApi.matchContactsInGroupBy(
-				groupId = groupId,
 				filter = mapContactFilterOptions(
 					filter,
 					config,
 					groupId
-				)
+				),
+				groupId = groupId,
 			).successBody()
 		}
 
@@ -1261,7 +1261,7 @@ private class ContactBasicApiImpl(
 	private suspend fun doMatchServicesBy(groupId: String?, filter: FilterOptions<Service>): List<String> =
 		if (groupId == null) {
 			rawApi.matchServicesBy(
-				mapServiceFilterOptions(
+				filter = mapServiceFilterOptions(
 					filter,
 					config,
 					groupId

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DataOwnerApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DataOwnerApiImpl.kt
@@ -42,10 +42,10 @@ class DataOwnerApiImpl(
 		getOrCacheInfo().first.hierarchy
 
 	override suspend fun getDataOwner(ownerId: String): DataOwnerWithType =
-		rawApi.getDataOwner(ownerId).successBody()
+		rawApi.getDataOwner(dataOwnerId = ownerId).successBody()
 
 	override suspend fun getCryptoActorStub(ownerId: String): CryptoActorStubWithType =
-		rawApi.getDataOwnerStub(ownerId).successBody()
+		rawApi.getDataOwnerStub(dataOwnerId = ownerId).successBody()
 
 	override suspend fun getCurrentDataOwnerHierarchyIdsFrom(parentId: String): List<String> {
 		getCurrentDataOwnerHierarchyIds()
@@ -62,7 +62,7 @@ class DataOwnerApiImpl(
 		}
 
 	override suspend fun modifyDataOwnerStub(cryptoActorStubWithTypeDto: CryptoActorStubWithType): CryptoActorStubWithType =
-		rawApi.modifyDataOwnerStub(cryptoActorStubWithTypeDto).successBodyOrThrowRevisionConflict()
+		rawApi.modifyDataOwnerStub(updated = cryptoActorStubWithTypeDto).successBodyOrThrowRevisionConflict()
 
 	override suspend fun getCurrentDataOwnerType(): DataOwnerType =
 		getOrCacheInfo().first.type
@@ -101,9 +101,9 @@ class DataOwnerApiImpl(
 	override suspend fun getCryptoActorStubInGroup(entityReferenceInGroup: EntityReferenceInGroup): CryptoActorStubWithType {
 		val dataOwnerGroup = entityReferenceInGroup.normalized(boundGroup).groupId
 		return if (dataOwnerGroup == null) {
-			rawApi.getDataOwnerStub(entityReferenceInGroup.entityId).successBody()
+			rawApi.getDataOwnerStub(dataOwnerId = entityReferenceInGroup.entityId).successBody()
 		} else {
-			rawApi.getCryptoActorStubInGroup(dataOwnerGroup, entityReferenceInGroup.entityId).successBody()
+			rawApi.getCryptoActorStubInGroup(groupId = dataOwnerGroup, dataOwnerId = entityReferenceInGroup.entityId).successBody()
 		}
 	}
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DeviceApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DeviceApiImpl.kt
@@ -35,107 +35,107 @@ internal abstract class AbstractDeviceApi(
 	protected suspend fun doCreateDevice(groupId: String?, entity: Device): Device {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createDevice(entity)
+			rawApi.createDevice(p = entity)
 		} else {
-			rawApi.createDeviceInGroup(groupId, entity)
+			rawApi.createDeviceInGroup(groupId = groupId, deviceDto = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateDevices(groupId: String?, entities: List<Device>): List<Device> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.createDevices(calendarItemTypes)
+				rawApi.createDevices(deviceDtos = calendarItemTypes)
 			} else {
-				rawApi.createDevicesInGroup(groupId, calendarItemTypes)
+				rawApi.createDevicesInGroup(groupId = groupId, deviceDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doGetDevice(groupId: String?, entityId: String): Device? =
 		if (groupId == null) {
-			rawApi.getDevice(entityId)
+			rawApi.getDevice(deviceId = entityId)
 		} else {
-			rawApi.getDeviceInGroup(groupId, entityId)
+			rawApi.getDeviceInGroup(groupId = groupId, deviceId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetDevices(groupId: String?, entityIds: List<String>): List<Device> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getDevices(ListOfIds(ids))
+				rawApi.getDevices(deviceIds = ListOfIds(ids))
 			} else {
-				rawApi.getDevicesInGroup(groupId, ListOfIds(ids))
+				rawApi.getDevicesInGroup(groupId = groupId, deviceIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyDevice(groupId: String?, entity: Device): Device {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.updateDevice(entity)
+			rawApi.updateDevice(deviceDto = entity)
 		} else {
-			rawApi.modifyDeviceInGroup(groupId, entity)
+			rawApi.modifyDeviceInGroup(groupId = groupId, deviceDto = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyDevices(groupId: String?, entities: List<Device>): List<Device> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.updateDevices(calendarItemTypes)
+				rawApi.updateDevices(deviceDtos = calendarItemTypes)
 			} else {
-				rawApi.modifyDevicesInGroup(groupId, calendarItemTypes)
+				rawApi.modifyDevicesInGroup(groupId = groupId, deviceDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteDevice(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteDevice(entityId, rev)
+			rawApi.deleteDevice(deviceId = entityId, rev = rev)
 		} else {
-			rawApi.deleteDeviceInGroup(groupId, entityId, rev)
+			rawApi.deleteDeviceInGroup(groupId = groupId, deviceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteDevices(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteDevicesWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteDevicesWithRev(deviceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteDevicesInGroupWithRev(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteDevicesInGroupWithRev(groupId = groupId, deviceIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteDevice(groupId: String?, entityId: String, rev: String): Device =
 		if (groupId == null) {
-			rawApi.undeleteDevice(entityId, rev)
+			rawApi.undeleteDevice(deviceId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteDeviceInGroup(groupId, entityId, rev)
+			rawApi.undeleteDeviceInGroup(groupId = groupId, deviceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteDevices(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<Device> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteDevices(ListOfIdsAndRev(ids))
+				rawApi.undeleteDevices(deviceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteDevicesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteDevicesInGroup(groupId = groupId, deviceIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeDevice(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeDevice(entityId, rev)
+			rawApi.purgeDevice(deviceId = entityId, rev = rev)
 		} else {
-			rawApi.purgeDeviceInGroup(groupId, entityId, rev)
+			rawApi.purgeDeviceInGroup(groupId = groupId, deviceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeDevices(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeDevices(ListOfIdsAndRev(ids))
+				rawApi.purgeDevices(deviceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeDevicesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeDevicesInGroup(groupId = groupId, deviceIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doMatchDevicesBy(groupId: String?, filter: BaseFilterOptions<Device>): List<String> =
 		if (groupId == null) {
-			rawApi.matchDevicesBy(mapDeviceFilterOptions(filter, config))
+			rawApi.matchDevicesBy(filter = mapDeviceFilterOptions(filter, config))
 		} else {
 			rawApi.matchDevicesInGroupBy(groupId = groupId, filter = mapDeviceFilterOptions(filter, config, groupId))
 		}.successBody()

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DocumentApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DocumentApiImpl.kt
@@ -96,9 +96,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createDocument(encrypted)
+			rawApi.createDocument(documentDto = encrypted)
 		} else {
-			rawApi.createDocumentInGroup(groupId, encrypted)
+			rawApi.createDocumentInGroup(groupId = groupId, documentDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -107,9 +107,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 	protected suspend fun doCreateDocuments(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { documents ->
 		val encrypted = validateAndMaybeEncrypt(groupId, documents)
 		if (groupId == null) {
-			rawApi.createDocuments(encrypted)
+			rawApi.createDocuments(documentDtos = encrypted)
 		} else {
-			rawApi.createDocumentsInGroup(groupId, encrypted)
+			rawApi.createDocumentsInGroup(groupId = groupId, documentDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -117,7 +117,7 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 
 	protected suspend fun doUndeleteDocument(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteDocument(entityId, rev)
+			rawApi.undeleteDocument(documentId = entityId, rev = rev)
 		} else {
 			rawApi.undeleteDocumentInGroup(groupId = groupId, documentId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
@@ -125,9 +125,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 	protected suspend fun doUndeleteDocuments(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteDocuments(ListOfIdsAndRev(ids))
+				rawApi.undeleteDocuments(documentIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteDocumentsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteDocumentsInGroup(groupId = groupId, documentIds = ListOfIdsAndRev(ids))
 			}.successBody().let { maybeDecrypt(entitiesGroupId = groupId, entities = it) }
 		}
 
@@ -135,9 +135,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyDocument(encrypted)
+			rawApi.modifyDocument(documentDto = encrypted)
 		} else {
-			rawApi.modifyDocumentInGroup(groupId, encrypted)
+			rawApi.modifyDocumentInGroup(groupId = groupId, documentDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -146,9 +146,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 	protected suspend fun doModifyDocuments(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { documents ->
 		val encrypted = validateAndMaybeEncrypt(groupId, documents)
 		return if (groupId == null) {
-			rawApi.modifyDocuments(encrypted)
+			rawApi.modifyDocuments(documentDtos = encrypted)
 		} else {
-			rawApi.modifyDocumentsInGroup(groupId, encrypted)
+			rawApi.modifyDocumentsInGroup(groupId = groupId, documentDtos = encrypted)
 		}.successBodyOrThrowRevisionConflict().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -156,7 +156,7 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 
 	protected suspend fun doGetDocument(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getDocument(entityId)
+			rawApi.getDocument(documentId = entityId)
 		} else {
 			rawApi.getDocumentInGroup(groupId = groupId, documentId = entityId)
 		}.successBodyOrNull404()?.let {
@@ -165,9 +165,9 @@ private abstract class AbstractDocumentBasicFlavouredApi<E : Document>(
 
 	suspend fun doGetDocuments(groupId: String?, entityIds: List<String>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getDocuments(ListOfIds(ids))
+			rawApi.getDocuments(documentIds = ListOfIds(ids))
 		} else {
-			rawApi.getDocumentsInGroup(groupId, ListOfIds(ids))
+			rawApi.getDocumentsInGroup(groupId = groupId, documentIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -274,9 +274,9 @@ private abstract class AbstractDocumentFlavouredApi<E : Document>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -288,7 +288,7 @@ private abstract class AbstractDocumentFlavouredApi<E : Document>(
 	): PaginatedListIterator<T> =
 		IdsPageIterator(
 			rawApi.matchDocumentsBy(
-				mapDocumentFilterOptions(
+				filter = mapDocumentFilterOptions(
 					filter,
 					config,
 					groupId
@@ -374,34 +374,34 @@ private abstract class AbstractDocumentBasicFlavourless(
 
 	protected suspend fun doDeleteDocument(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteDocument(entityId, rev)
+			rawApi.deleteDocument(documentId = entityId, rev = rev)
 		} else {
-			rawApi.deleteDocumentInGroup(groupId, entityId, rev)
+			rawApi.deleteDocumentInGroup(groupId = groupId, documentId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteDocuments(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteDocumentsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteDocumentsWithRev(documentIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteDocumentsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteDocumentsInGroup(groupId = groupId, documentIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeDocument(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeDocument(entityId, rev)
+			rawApi.purgeDocument(documentId = entityId, rev = rev)
 		} else {
-			rawApi.purgeDocumentInGroup(groupId, entityId, rev)
+			rawApi.purgeDocumentInGroup(groupId = groupId, documentId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeDocuments(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeDocuments(ListOfIdsAndRev(ids))
+				rawApi.purgeDocuments(documentIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeDocumentsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeDocumentsInGroup(groupId = groupId, documentIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }
@@ -423,10 +423,10 @@ private class DocumentBasicFlavourlessApiImpl(rawApi: RawDocumentApi) : Abstract
 		doPurgeDocuments(groupId = null, entityIds = entityIds)
 
 	override suspend fun getRawMainAttachment(documentId: String) =
-		rawApi.getMainAttachment(documentId).successBody()
+		rawApi.getMainAttachment(documentId = documentId).successBody()
 
 	override suspend fun getRawSecondaryAttachment(documentId: String, key: String) =
-		rawApi.getSecondaryAttachment(documentId, key).successBody()
+		rawApi.getSecondaryAttachment(documentId = documentId, key = key).successBody()
 
 	override suspend fun setRawMainAttachment(
 		documentId: String,
@@ -435,7 +435,14 @@ private class DocumentBasicFlavourlessApiImpl(rawApi: RawDocumentApi) : Abstract
 		attachment: ByteArray,
 		encrypted: Boolean,
 	) =
-		rawApi.setDocumentAttachment(documentId, rev, utis, payload = attachment, lengthHeader = attachment.size.toLong(), encrypted = encrypted).successBody()
+		rawApi.setDocumentAttachment(
+			documentId = documentId,
+			rev = rev,
+			utis = utis,
+			payload = attachment,
+			lengthHeader = attachment.size.toLong(),
+			encrypted = encrypted
+		).successBody()
 
 	override suspend fun setRawSecondaryAttachment(
 		documentId: String,
@@ -445,13 +452,21 @@ private class DocumentBasicFlavourlessApiImpl(rawApi: RawDocumentApi) : Abstract
 		attachment: ByteArray,
 		encrypted: Boolean,
 	) =
-		rawApi.setSecondaryAttachment(documentId, key, rev, utis, payload = attachment, lengthHeader = attachment.size.toLong(), encrypted = encrypted).successBody()
+		rawApi.setSecondaryAttachment(
+			documentId = documentId,
+			key = key,
+			rev = rev,
+			utis = utis,
+			payload = attachment,
+			lengthHeader = attachment.size.toLong(),
+			encrypted = encrypted
+		).successBody()
 
 	override suspend fun deleteMainAttachment(entityId: String, rev: String) =
-		rawApi.deleteAttachment(entityId, rev).successBody()
+		rawApi.deleteAttachment(documentId = entityId, rev = rev).successBody()
 
 	override suspend fun deleteSecondaryAttachment(documentId: String, key: String, rev: String) =
-		rawApi.deleteSecondaryAttachment(documentId, key, rev).successBody()
+		rawApi.deleteSecondaryAttachment(documentId = documentId, key = key, rev = rev).successBody()
 }
 
 @InternalIcureApi
@@ -695,8 +710,14 @@ private class DocumentApiImpl(
 		document: Document,
 		decryptedAttachmentValidator: (suspend (document: ByteArray) -> Boolean)?
 	) =
-		rawApi.getMainAttachment(document.id).successBody().let {
-			crypto.entity.decryptAttachmentOf(null, document, EntityWithEncryptionMetadataTypeName.Document, it, decryptedAttachmentValidator)
+		rawApi.getMainAttachment(documentId = document.id).successBody().let {
+			crypto.entity.decryptAttachmentOf(
+				entityGroupId = null,
+				entity = document,
+				entityType = EntityWithEncryptionMetadataTypeName.Document,
+				content = it,
+				validator = decryptedAttachmentValidator
+			)
 		}
 
 	override suspend fun encryptAndSetMainAttachment(document: Document, utis: List<String>?, attachment: ByteArray): EncryptedDocument {
@@ -704,9 +725,9 @@ private class DocumentApiImpl(
 			?: throw EntityEncryptionException("Cannot extract encryption key from document")
 		val payload = crypto.primitives.aes.encrypt(attachment, aesKey)
 		return rawApi.setDocumentAttachment(
-			document.id,
-			document.rev ?: throw IllegalArgumentException("Document must have a revision set before setting the attachment"),
-			utis,
+			documentId = document.id,
+			rev = document.rev ?: throw IllegalArgumentException("Document must have a revision set before setting the attachment"),
+			utis = utis,
 			payload = payload,
 			lengthHeader = attachment.size.toLong(),
 			encrypted = true,
@@ -718,8 +739,14 @@ private class DocumentApiImpl(
 		key: String,
 		decryptedAttachmentValidator: (suspend (document: ByteArray) -> Boolean)?
 	) =
-		rawApi.getSecondaryAttachment(document.id, key).successBody().let {
-			crypto.entity.decryptAttachmentOf(null, document, EntityWithEncryptionMetadataTypeName.Document, it, decryptedAttachmentValidator)
+		rawApi.getSecondaryAttachment(documentId = document.id, key = key).successBody().let {
+			crypto.entity.decryptAttachmentOf(
+				entityGroupId = null,
+				entity = document,
+				entityType = EntityWithEncryptionMetadataTypeName.Document,
+				content = it,
+				validator = decryptedAttachmentValidator
+			)
 		}
 
 	override suspend fun encryptAndSetSecondaryAttachment(
@@ -732,10 +759,10 @@ private class DocumentApiImpl(
 			?: throw EntityEncryptionException("Cannot extract encryption key from document")
 		val payload = crypto.primitives.aes.encrypt(attachment, aesKey)
 		return rawApi.setSecondaryAttachment(
-			document.id,
-			key,
-			document.rev ?: throw IllegalArgumentException("Document must have a revision set before setting the attachment"),
-			utis,
+			documentId = document.id,
+			key = key,
+			rev = document.rev ?: throw IllegalArgumentException("Document must have a revision set before setting the attachment"),
+			utis = utis,
 			payload = payload,
 			lengthHeader = attachment.size.toLong(),
 			encrypted = true,
@@ -799,7 +826,7 @@ private class DocumentApiImpl(
 	private suspend fun doMatchDocumentsBy(groupId: String?, filter: FilterOptions<Document>): List<String> =
 		if (groupId == null) {
 			rawApi.matchDocumentsBy(
-				mapDocumentFilterOptions(
+				filter = mapDocumentFilterOptions(
 					filter,
 					config,
 					groupId
@@ -886,7 +913,7 @@ private class DocumentBasicApiImpl(
 	private suspend fun doMatchDocumentsBy(groupId: String?, filter: BaseFilterOptions<Document>): List<String> =
 		if (groupId == null) {
 			rawApi.matchDocumentsBy(
-				mapDocumentFilterOptions(
+				filter = mapDocumentFilterOptions(
 					filter,
 					config,
 					groupId

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/FormApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/FormApiImpl.kt
@@ -98,9 +98,9 @@ private abstract class AbstractFormBasicFlavouredApi<E : Form>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createForm(encrypted)
+			rawApi.createForm(ft = encrypted)
 		} else {
-			rawApi.createFormInGroup(groupId, encrypted)
+			rawApi.createFormInGroup(groupId = groupId, formDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -109,9 +109,9 @@ private abstract class AbstractFormBasicFlavouredApi<E : Form>(
 	protected suspend fun doCreateForms(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { forms ->
 		val encrypted = validateAndMaybeEncrypt(groupId, forms)
 		return if (groupId == null) {
-			rawApi.createForms(encrypted)
+			rawApi.createForms(formDtos = encrypted)
 		} else {
-			rawApi.createFormsInGroup(groupId, encrypted)
+			rawApi.createFormsInGroup(groupId = groupId, formDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -119,16 +119,16 @@ private abstract class AbstractFormBasicFlavouredApi<E : Form>(
 
 	protected suspend fun doUndeleteForm(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteForm(entityId, rev)
+			rawApi.undeleteForm(formId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteFormInGroup(groupId, entityId, rev)
+			rawApi.undeleteFormInGroup(groupId = groupId, formId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteForms(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteForms(ListOfIdsAndRev(ids))
+			rawApi.undeleteForms(formIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteFormsInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteFormsInGroup(groupId = groupId, formIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -136,18 +136,18 @@ private abstract class AbstractFormBasicFlavouredApi<E : Form>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyForm(encrypted)
+			rawApi.modifyForm(formDto = encrypted)
 		} else {
-			rawApi.modifyFormInGroup(groupId, encrypted)
+			rawApi.modifyFormInGroup(groupId = groupId, formDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyForms(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { forms ->
 		val encrypted = validateAndMaybeEncrypt(groupId, forms)
 		return if (groupId == null) {
-			rawApi.modifyForms(encrypted)
+			rawApi.modifyForms(formDtos = encrypted)
 		} else {
-			rawApi.modifyFormsInGroup(groupId, encrypted)
+			rawApi.modifyFormsInGroup(groupId = groupId, formDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -155,16 +155,16 @@ private abstract class AbstractFormBasicFlavouredApi<E : Form>(
 
 	protected suspend fun doGetForm(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getForm(entityId)
+			rawApi.getForm(formId = entityId)
 		} else {
-			rawApi.getFormInGroup(groupId, entityId)
+			rawApi.getFormInGroup(groupId = groupId, formId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	suspend fun doGetForms(groupId: String?, entityIds: List<String>) = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getForms(ListOfIds(ids))
+			rawApi.getForms(formIds = ListOfIds(ids))
 		} else {
-			rawApi.getFormsInGroup(groupId, ListOfIds(ids))
+			rawApi.getFormsInGroup(groupId = groupId, formIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 }
@@ -199,7 +199,8 @@ private class FormBasicFlavouredApiImpl<E: Form>(
 
 	override suspend fun getForms(entityIds: List<String>): List<E> = doGetForms(groupId = null, entityIds)
 
-	override suspend fun getLatestFormByUniqueId(uniqueId: String) = rawApi.getFormByUniqueId(uniqueId).successBody().let { maybeDecrypt(null, it) }
+	override suspend fun getLatestFormByUniqueId(uniqueId: String) =
+		rawApi.getFormByUniqueId(uniqueId = uniqueId).successBody().let { maybeDecrypt(null, it) }
 }
 
 @InternalIcureApi
@@ -273,9 +274,9 @@ private abstract class AbstractFormFlavouredApi<E : Form>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -287,7 +288,7 @@ private abstract class AbstractFormFlavouredApi<E : Form>(
 	): PaginatedListIterator<T> =
 		IdsPageIterator(
 			rawApi.matchFormsBy(
-				mapFormFilterOptions(
+				filter = mapFormFilterOptions(
 					filter,
 					config,
 					groupId

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/FrontEndMigrationApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/FrontEndMigrationApiImpl.kt
@@ -12,16 +12,19 @@ internal  class FrontEndMigrationApiImpl(
 	private val rawApi: RawFrontEndMigrationApi,
 ) : FrontEndMigrationApi {
 	override suspend fun getFrontEndMigration(frontEndMigrationId: String) =
-		rawApi.getFrontEndMigration(frontEndMigrationId).successBodyOrNull404()
+		rawApi.getFrontEndMigration(frontEndMigrationId = frontEndMigrationId).successBodyOrNull404()
 
 	override suspend fun createFrontEndMigration(frontEndMigration: FrontEndMigration) =
-		rawApi.createFrontEndMigration(frontEndMigration).successBody()
+		rawApi.createFrontEndMigration(frontEndMigrationDto = frontEndMigration).successBody()
 
 	override suspend fun getFrontEndMigrations() = rawApi.getFrontEndMigrations().successBody()
 
-	override suspend fun deleteFrontEndMigration(frontEndMigrationId: String) = rawApi.deleteFrontEndMigration(frontEndMigrationId).successBody()
+	override suspend fun deleteFrontEndMigration(frontEndMigrationId: String) =
+		rawApi.deleteFrontEndMigration(frontEndMigrationId = frontEndMigrationId).successBody()
 
-	override suspend fun getFrontEndMigrationByName(frontEndMigrationName: String) = rawApi.getFrontEndMigrationByName(frontEndMigrationName).successBody()
+	override suspend fun getFrontEndMigrationByName(frontEndMigrationName: String) =
+		rawApi.getFrontEndMigrationByName(frontEndMigrationName = frontEndMigrationName).successBody()
 
-	override suspend fun modifyFrontEndMigration(frontEndMigration: FrontEndMigration) = rawApi.modifyFrontEndMigration(frontEndMigration).successBodyOrThrowRevisionConflict()
+	override suspend fun modifyFrontEndMigration(frontEndMigration: FrontEndMigration) =
+		rawApi.modifyFrontEndMigration(frontEndMigrationDto = frontEndMigration).successBodyOrThrowRevisionConflict()
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/GroupApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/GroupApiImpl.kt
@@ -30,7 +30,7 @@ internal class GroupApiImpl(
 	private val rawApi: RawGroupApi,
 ) : GroupApi {
 	override suspend fun listGroups(): List<Group> = rawApi.listGroups().successBody()
-	override suspend fun getGroup(id: String): Group = rawApi.getGroup(id).successBody()
+	override suspend fun getGroup(id: String): Group = rawApi.getGroup(id = id).successBody()
 	override suspend fun createGroup(
 		id: String,
 		name: String,
@@ -58,7 +58,7 @@ internal class GroupApiImpl(
 	override suspend fun registerNewGroupAdministrator(
 		type: GroupType?,
 		registrationInformation: RegistrationInformation,
-	): RegistrationSuccess = rawApi.registerNewGroupAdministrator(type, registrationInformation).successBody()
+	): RegistrationSuccess = rawApi.registerNewGroupAdministrator(type = type, registrationInformation = registrationInformation).successBody()
 
 	override suspend fun listApps(): List<Group> = rawApi.listApps().successBody()
 
@@ -67,7 +67,7 @@ internal class GroupApiImpl(
 		id: String,
 		startDocumentId: String?,
 		limit: Int?,
-	): PaginatedList<Group> = rawApi.findGroups(id, startDocumentId, limit).successBody()
+	): PaginatedList<Group> = rawApi.findGroups(id = id, startDocumentId = startDocumentId, limit = limit).successBody()
 
 	@Deprecated("Will be replaced by filters")
 	override suspend fun findGroupsWithContent(
@@ -77,82 +77,88 @@ internal class GroupApiImpl(
 		startDocumentId: String?,
 		limit: Int?,
 	): PaginatedList<Group> =
-		rawApi.findGroupsWithContent(id, searchString, startKey.encodeStartKey(), startDocumentId, limit).successBody()
+		rawApi.findGroupsWithContent(
+			id = id,
+			searchString = searchString,
+			startKey = startKey.encodeStartKey(),
+			startDocumentId = startDocumentId,
+			limit = limit,
+		).successBody()
 
-	override suspend fun getNameOfGroupParent(id: String): String = rawApi.getNameOfGroupParent(id).successBody()
+	override suspend fun getNameOfGroupParent(id: String): String = rawApi.getNameOfGroupParent(id = id).successBody()
 
-	override suspend fun modifyGroupName(id: String, name: String): Group = rawApi.modifyGroupName(id, name).successBody()
+	override suspend fun modifyGroupName(id: String, name: String): Group = rawApi.modifyGroupName(id = id, name = name).successBody()
 
 	override suspend fun getOperationToken(
 		operation: Operation,
 		duration: Long?,
 		description: String?,
-	): String = rawApi.getOperationToken(operation, duration, description).successBody()
+	): String = rawApi.getOperationToken(operation = operation, duration = duration, description = description).successBody()
 
-	override suspend fun deleteOperationToken(tokenId: String): Unit = rawApi.deleteOperationToken(tokenId).successBody()
+	override suspend fun deleteOperationToken(tokenId: String): Unit = rawApi.deleteOperationToken(tokenId = tokenId).successBody()
 
 	override suspend fun setDefaultRoles(
 		groupId: String,
 		userType: String,
 		roleIds: List<String>,
-	): Group = rawApi.setDefaultRoles(groupId, userType, ListOfIds(roleIds)).successBody()
+	): Group = rawApi.setDefaultRoles(groupId = groupId, userType = userType, roleIds = ListOfIds(roleIds)).successBody()
 
 	override suspend fun getDefaultRoles(groupId: String): Map<UserType, List<RoleConfiguration>> =
-		rawApi.getDefaultRoles(groupId).successBody()
+		rawApi.getDefaultRoles(groupId = groupId).successBody()
 
-	override suspend fun deleteGroup(id: String): Group = rawApi.deleteGroup(id).successBody()
+	override suspend fun deleteGroup(id: String): Group = rawApi.deleteGroup(id = id).successBody()
 	override suspend fun changeSuperGroup(childGroupId: String, operationToken: String): Group =
-		rawApi.changeSuperGroup(childGroupId, operationToken).successBody()
+		rawApi.changeSuperGroup(childGroupId = childGroupId, operationToken = operationToken).successBody()
 
-	override suspend fun hardDeleteGroup(id: String): List<GroupDeletionReport> = rawApi.hardDeleteGroup(id).successBody()
+	override suspend fun hardDeleteGroup(id: String): List<GroupDeletionReport> = rawApi.hardDeleteGroup(id = id).successBody()
 	override suspend fun modifyGroupProperties(id: String, properties: ListOfProperties): Group =
-		rawApi.modifyGroupProperties(id, properties).successBody()
+		rawApi.modifyGroupProperties(id = id, properties = properties).successBody()
 
 	override suspend fun setGroupPassword(id: String, password: String): Group =
-		rawApi.setGroupPassword(id, password).successBody()
+		rawApi.setGroupPassword(id = id, password = password).successBody()
 
 	override suspend fun initDesignDocs(
 		id: String,
 		clazz: String?,
 		warmup: Boolean?,
 		dryRun: Boolean?
-	): List<DesignDocument> = rawApi.initDesignDocs(id, clazz, warmup, dryRun).successBody()
+	): List<DesignDocument> = rawApi.initDesignDocs(id = id, clazz = clazz, warmup = warmup, dryRun = dryRun).successBody()
 
 	override suspend fun solveConflicts(id: String, limit: Int?, warmup: Boolean?): List<IdWithRev> =
-		rawApi.solveConflicts(id, limit, warmup).successBody()
+		rawApi.solveConflicts(groupId = id, limit = limit, warmup = warmup).successBody()
 
 	override suspend fun resetStorage(id: String, q: Int?, n: Int?, databases: List<String>): Unit =
-		rawApi.resetStorage(id, q, n, ListOfIds(databases)).successBody()
+		rawApi.resetStorage(id = id, q = q, n = n, databases = ListOfIds(databases)).successBody()
 
 	override suspend fun getGroupsStorageInfos(groups: List<String>): List<GroupDatabasesInfo> =
-		rawApi.getGroupsStorageInfos(ListOfIds(groups)).successBody()
+		rawApi.getGroupsStorageInfos(groups = ListOfIds(groups)).successBody()
 
 	override suspend fun modifyGroupApplicationId(
 		id: String,
 		applicationId: String,
-	): Group = rawApi.modifyGroupApplicationId(id, applicationId).successBody()
+	): Group = rawApi.modifyGroupApplicationId(id = id, applicationId = applicationId).successBody()
 
 	override suspend fun addTagToGroup(
 		id: String,
 		rev: String,
 		tag: CodeStub,
-	): Group = rawApi.addTagToGroup(id, rev, tag).successBody()
+	): Group = rawApi.addTagToGroup(id = id, rev = rev, tag = tag).successBody()
 
 	override suspend fun removeTagFromGroup(
 		id: String,
 		rev: String,
 		tagId: String,
-	): Group = rawApi.removeTagFromGroup(id, rev, tagId).successBody()
+	): Group = rawApi.removeTagFromGroup(id = id, rev = rev, tagId = tagId).successBody()
 
-	override suspend fun getReplicationInfo(id: String): ReplicationInfo = rawApi.getReplicationInfo(id).successBody()
-	override suspend fun getHierarchy(id: String): List<String> = rawApi.getHierarchy(id).successBody()
+	override suspend fun getReplicationInfo(id: String): ReplicationInfo = rawApi.getReplicationInfo(id = id).successBody()
+	override suspend fun getHierarchy(id: String): List<String> = rawApi.getHierarchy(id = id).successBody()
 	override suspend fun listAllGroupsIds(): List<DocIdentifier> = rawApi.listAllGroupsIds().successBody()
 	override suspend fun createOrUpdateExternalJwtConfig(groupId: String, key: String, config: ExternalJwtConfig): Group =
-		rawApi.createOrUpdateExternalJwtConfig(groupId, key, config).successBody()
+		rawApi.createOrUpdateExternalJwtConfig(groupId = groupId, key = key, config = config).successBody()
 	override suspend fun removeExternalJwtConfig(groupId: String, key: String): Group =
-		rawApi.removeExternalJwtConfig(groupId, key).successBody()
+		rawApi.removeExternalJwtConfig(groupId = groupId, key = key).successBody()
 	override suspend fun getOperationTokenForGroup(groupId: String, operation: Operation, duration: Long?, description: String?): String =
-		rawApi.getOperationTokenForGroup(groupId, operation, duration, description).successBody()
+		rawApi.getOperationTokenForGroup(groupId = groupId, operation = operation, duration = duration, description = description).successBody()
 
 	override suspend fun setGroupProjectId(
 		groupId: String,
@@ -160,8 +166,8 @@ internal class GroupApiImpl(
 		applyToSubgroups: Boolean
 	) {
 		if (projectId == null)
-			rawApi.deleteGroupApplicationId(groupId, applyToSubgroups).successBody()
+			rawApi.deleteGroupApplicationId(id = groupId, applyToSubGroups = applyToSubgroups).successBody()
 		else
-			rawApi.modifyGroupApplicationId(groupId, projectId, applyToSubgroups).successBody()
+			rawApi.modifyGroupApplicationId(id = groupId, applicationId = projectId, applyToSubGroups = applyToSubgroups).successBody()
 	}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/HealthElementApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/HealthElementApiImpl.kt
@@ -98,7 +98,7 @@ private suspend fun RawHealthElementApi.doMatchHealthElementsBy(
 ): List<String> =
 	if (groupId == null) {
 		matchHealthElementsBy(
-			mapHealthElementFilterOptions(
+			filter = mapHealthElementFilterOptions(
 				filter,
 				config,
 				requestGroup = null
@@ -106,12 +106,12 @@ private suspend fun RawHealthElementApi.doMatchHealthElementsBy(
 		)
 	} else {
 		matchHealthElementsInGroupBy(
-			groupId = groupId,
 			filter = mapHealthElementFilterOptions(
 				filter,
 				config,
 				requestGroup = groupId
-			)
+			),
+			groupId = groupId
 		)
 	}.successBody()
 
@@ -133,9 +133,9 @@ private abstract class AbstractHealthElementBasicFlavouredApi<E : HealthElement>
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createHealthElement(encrypted)
+			rawApi.createHealthElement(c = encrypted)
 		} else {
-			rawApi.createHealthElementInGroup(groupId, encrypted)
+			rawApi.createHealthElementInGroup(groupId = groupId, healthElementDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -144,9 +144,9 @@ private abstract class AbstractHealthElementBasicFlavouredApi<E : HealthElement>
 	protected suspend fun doCreateHealthElements(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { healthElements ->
 		val encrypted = validateAndMaybeEncrypt(groupId, healthElements)
 		return if (groupId == null) {
-			rawApi.createHealthElements(encrypted)
+			rawApi.createHealthElements(healthElementDtos = encrypted)
 		} else {
-			rawApi.createHealthElementsInGroup(groupId, encrypted)
+			rawApi.createHealthElementsInGroup(groupId = groupId, healthElementDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -154,16 +154,16 @@ private abstract class AbstractHealthElementBasicFlavouredApi<E : HealthElement>
 
 	protected suspend fun doUndeleteHealthElement(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteHealthElement(entityId, rev)
+			rawApi.undeleteHealthElement(healthElementId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteHealthElementInGroup(groupId, entityId, rev)
+			rawApi.undeleteHealthElementInGroup(groupId = groupId, healthElementId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteHealthElements(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteHealthElements(ListOfIdsAndRev(ids))
+			rawApi.undeleteHealthElements(healthElementIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteHealthElementsInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteHealthElementsInGroup(groupId = groupId, healthElementIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -171,18 +171,18 @@ private abstract class AbstractHealthElementBasicFlavouredApi<E : HealthElement>
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyHealthElement(encrypted)
+			rawApi.modifyHealthElement(healthElementDto = encrypted)
 		} else {
-			rawApi.modifyHealthElementInGroup(groupId, encrypted)
+			rawApi.modifyHealthElementInGroup(groupId = groupId, healthElementDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyHealthElements(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { healthElements ->
 		val encrypted = validateAndMaybeEncrypt(groupId, healthElements)
 		return if (groupId == null) {
-			rawApi.modifyHealthElements(encrypted)
+			rawApi.modifyHealthElements(healthElementDtos = encrypted)
 		} else {
-			rawApi.modifyHealthElementsInGroup(groupId, encrypted)
+			rawApi.modifyHealthElementsInGroup(groupId = groupId, healthElementDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -190,16 +190,16 @@ private abstract class AbstractHealthElementBasicFlavouredApi<E : HealthElement>
 
 	protected suspend fun doGetHealthElement(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getHealthElement(entityId)
+			rawApi.getHealthElement(healthElementId = entityId)
 		} else {
 			rawApi.getHealthElementInGroup(groupId = groupId, healthElementId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	suspend fun doGetHealthElements(groupId: String?, entityIds: List<String>) = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getHealthElements(ListOfIds(ids))
+			rawApi.getHealthElements(healthElementIds = ListOfIds(ids))
 		} else {
-			rawApi.getHealthElementsInGroup(groupId, ListOfIds(ids))
+			rawApi.getHealthElementsInGroup(groupId = groupId, healthElementIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 }
@@ -306,9 +306,9 @@ private abstract class AbstractHealthElementFlavouredApi<E : HealthElement>(
 				maybeDecrypt(
 					entityGroupId,
 					if (entityGroupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, entityGroupId).successBody()
+						rawApi.bulkShare(request = it, groupId = entityGroupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -392,34 +392,34 @@ private abstract class AbstractHealthElementBasicFlavourless(
 
 	protected suspend fun doDeleteHealthElement(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteHealthElement(entityId, rev)
+			rawApi.deleteHealthElement(healthElementId = entityId, rev = rev)
 		} else {
-			rawApi.deleteHealthElementInGroup(groupId, entityId, rev)
+			rawApi.deleteHealthElementInGroup(groupId = groupId, healthElementId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteHealthElements(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteHealthElementsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteHealthElementsWithRev(healthElementIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteHealthElementsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteHealthElementsInGroup(groupId = groupId, healthElementIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeHealthElement(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeHealthElement(entityId, rev)
+			rawApi.purgeHealthElement(healthElementId = entityId, rev = rev)
 		} else {
-			rawApi.purgeHealthElementInGroup(groupId, entityId, rev)
+			rawApi.purgeHealthElementInGroup(groupId = groupId, healthElementId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeHealthElements(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeHealthElements(ListOfIdsAndRev(ids))
+				rawApi.purgeHealthElements(healthElementIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeHealthElementsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeHealthElementsInGroup(groupId = groupId, healthElementIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/HealthcarePartyApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/HealthcarePartyApiImpl.kt
@@ -36,109 +36,109 @@ internal abstract class AbstractHealthcarePartyApi(
 	protected suspend fun doCreateHealthcareParty(groupId: String?, entity: HealthcareParty): HealthcareParty {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createHealthcareParty(entity)
+			rawApi.createHealthcareParty(h = entity)
 		} else {
-			rawApi.createHealthcarePartyInGroup(groupId, entity)
+			rawApi.createHealthcarePartyInGroup(groupId = groupId, h = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateHealthcareParties(groupId: String?, entities: List<HealthcareParty>): List<HealthcareParty> =
 		skipRequestOnEmptyList(entities) { healthcareParties ->
 			if (groupId == null) {
-				rawApi.createHealthcareParties(healthcareParties)
+				rawApi.createHealthcareParties(healthcareParties = healthcareParties)
 			} else {
-				rawApi.createHealthcarePartiesInGroup(groupId, healthcareParties)
+				rawApi.createHealthcarePartiesInGroup(groupId = groupId, healthcareParties = healthcareParties)
 			}.successBody()
 		}
 
 	protected suspend fun doGetHealthcareParty(groupId: String?, entityId: String): HealthcareParty? =
 		if (groupId == null) {
-			rawApi.getHealthcareParty(entityId)
+			rawApi.getHealthcareParty(healthcarePartyId = entityId)
 		} else {
-			rawApi.getHealthcarePartyInGroup(groupId, entityId)
+			rawApi.getHealthcarePartyInGroup(groupId = groupId, healthcarePartyId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetHealthcareParties(groupId: String?, entityIds: List<String>): List<HealthcareParty> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getHealthcareParties(ListOfIds(ids))
+				rawApi.getHealthcareParties(healthcarePartyIds = ListOfIds(ids))
 			} else {
-				rawApi.getHealthcarePartiesInGroup(groupId, ListOfIds(ids))
+				rawApi.getHealthcarePartiesInGroup(groupId = groupId, healthcarePartyIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyHealthcareParty(groupId: String?, entity: HealthcareParty): HealthcareParty {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyHealthcareParty(entity)
+			rawApi.modifyHealthcareParty(healthcarePartyDto = entity)
 		} else {
-			rawApi.modifyHealthcarePartyInGroup(groupId, entity)
+			rawApi.modifyHealthcarePartyInGroup(groupId = groupId, healthcarePartyDto = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyHealthcareParties(groupId: String?, entities: List<HealthcareParty>): List<HealthcareParty> =
 		skipRequestOnEmptyList(entities) { healthcareParties ->
 			if (groupId == null) {
-				rawApi.modifyHealthcareParties(healthcareParties)
+				rawApi.modifyHealthcareParties(healthcareParties = healthcareParties)
 			} else {
-				rawApi.modifyHealthcarePartiesInGroup(groupId, healthcareParties)
+				rawApi.modifyHealthcarePartiesInGroup(groupId = groupId, healthcareParties = healthcareParties)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteHealthcareParty(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteHealthcareParty(entityId, rev)
+			rawApi.deleteHealthcareParty(healthcarePartyId = entityId, rev = rev)
 		} else {
-			rawApi.deleteHealthcarePartyInGroup(groupId, entityId, rev)
+			rawApi.deleteHealthcarePartyInGroup(groupId = groupId, healthcarePartyId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteHealthcareParties(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteHealthcarePartiesWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteHealthcarePartiesWithRev(healthcarePartyIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteHealthcarePartiesInGroupWithRev(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteHealthcarePartiesInGroupWithRev(groupId = groupId, healthcarePartyIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteHealthcareParty(groupId: String?, entityId: String, rev: String): HealthcareParty =
 		if (groupId == null) {
-			rawApi.undeleteHealthcareParty(entityId, rev)
+			rawApi.undeleteHealthcareParty(healthcarePartyId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteHealthcarePartyInGroup(groupId, entityId, rev)
+			rawApi.undeleteHealthcarePartyInGroup(groupId = groupId, healthcarePartyId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteHealthcareParties(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<HealthcareParty> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteHealthcareParties(ListOfIdsAndRev(ids))
+				rawApi.undeleteHealthcareParties(healthcarePartyIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteHealthcarePartiesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteHealthcarePartiesInGroup(groupId = groupId, healthcarePartyIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeHealthcareParty(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeHealthcareParty(entityId, rev)
+			rawApi.purgeHealthcareParty(healthcarePartyId = entityId, rev = rev)
 		} else {
-			rawApi.purgeHealthcarePartyInGroup(groupId, entityId, rev)
+			rawApi.purgeHealthcarePartyInGroup(groupId = groupId, healthcarePartyId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeHealthcareParties(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeHealthcareParties(ListOfIdsAndRev(ids))
+				rawApi.purgeHealthcareParties(healthcarePartyIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeHealthcarePartiesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeHealthcarePartiesInGroup(groupId = groupId, healthcarePartyIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doMatchHealthcarePartiesBy(groupId: String?, filter: BaseFilterOptions<HealthcareParty>) =
 		if (groupId == null) {
-			rawApi.matchHealthcarePartiesBy(mapHealthcarePartyFilterOptions(filter))
+			rawApi.matchHealthcarePartiesBy(filter = mapHealthcarePartyFilterOptions(filter))
 		} else {
-			rawApi.matchHealthcarePartiesInGroupBy(groupId, mapHealthcarePartyFilterOptions(filter))
+			rawApi.matchHealthcarePartiesInGroupBy(groupId = groupId, filter = mapHealthcarePartyFilterOptions(filter))
 		}.successBody()
 
 	protected suspend fun doMatchHealthcarePartiesBySorted(groupId: String?, filter: BaseSortableFilterOptions<HealthcareParty>) =
@@ -177,7 +177,8 @@ internal class HealthcarePartyApiImpl(
 		return doModifyHealthcareParties(groupId = null, entities = healthcareParties)
 	}
 
-	override suspend fun getPublicKey(healthcarePartyId: String) = rawApi.getPublicKey(healthcarePartyId).successBody()
+	override suspend fun getPublicKey(healthcarePartyId: String) =
+		rawApi.getPublicKey(healthcarePartyId = healthcarePartyId).successBody()
 
 	override suspend fun matchHealthcarePartiesBy(filter: BaseFilterOptions<HealthcareParty>) =
 		doMatchHealthcarePartiesBy(groupId = null, filter = filter)
@@ -216,7 +217,13 @@ internal class HealthcarePartyApiImpl(
 		token: String?,
 		useShortToken: Boolean?,
 		hcp: HealthcareParty,
-	) = rawApi.registerHealthcareParty(groupId, parentHcPartyId, token, useShortToken, hcp).successBody()
+	) = rawApi.registerHealthcareParty(
+		groupId = groupId,
+		parentHcPartyId = parentHcPartyId,
+		token = token,
+		useShortToken = useShortToken,
+		hcp = hcp
+	).successBody()
 
 	override suspend fun subscribeToEvents(
 		events: Set<SubscriptionEventType>,

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/InsuranceApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/InsuranceApiImpl.kt
@@ -28,109 +28,109 @@ internal abstract class AbstractInsuranceApi(
 	protected suspend fun doCreateInsurance(groupId: String?, entity: Insurance): Insurance {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createInsurance(entity)
+			rawApi.createInsurance(insuranceDto = entity)
 		} else {
-			rawApi.createInsuranceInGroup(groupId, entity)
+			rawApi.createInsuranceInGroup(groupId = groupId, insurance = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateInsurances(groupId: String?, entities: List<Insurance>): List<Insurance> =
 		skipRequestOnEmptyList(entities) { insurances ->
 			if (groupId == null) {
-				rawApi.createInsurances(insurances)
+				rawApi.createInsurances(insuranceDtos = insurances)
 			} else {
-				rawApi.createInsurancesInGroup(groupId, insurances)
+				rawApi.createInsurancesInGroup(groupId = groupId, insuranceBatch = insurances)
 			}.successBody()
 		}
 
 	protected suspend fun doGetInsurance(groupId: String?, entityId: String): Insurance? =
 		if (groupId == null) {
-			rawApi.getInsurance(entityId)
+			rawApi.getInsurance(insuranceId = entityId)
 		} else {
-			rawApi.getInsuranceInGroup(groupId, entityId)
+			rawApi.getInsuranceInGroup(groupId = groupId, insuranceId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetInsurances(groupId: String?, entityIds: List<String>): List<Insurance> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getInsurances(ListOfIds(ids))
+				rawApi.getInsurances(insuranceIds = ListOfIds(ids))
 			} else {
-				rawApi.getInsurancesInGroup(groupId, ListOfIds(ids))
+				rawApi.getInsurancesInGroup(groupId = groupId, insuranceIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyInsurance(groupId: String?, entity: Insurance): Insurance {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyInsurance(entity)
+			rawApi.modifyInsurance(insuranceDto = entity)
 		} else {
-			rawApi.modifyInsuranceInGroup(groupId, entity)
+			rawApi.modifyInsuranceInGroup(groupId = groupId, insurance = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyInsurances(groupId: String?, entities: List<Insurance>): List<Insurance> =
 		skipRequestOnEmptyList(entities) { insurances ->
 			if (groupId == null) {
-				rawApi.modifyInsurances(insurances)
+				rawApi.modifyInsurances(insuranceDtos = insurances)
 			} else {
-				rawApi.modifyInsurancesInGroup(groupId, insurances)
+				rawApi.modifyInsurancesInGroup(groupId = groupId, insuranceBatch = insurances)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteInsurance(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteInsurance(entityId, rev)
+			rawApi.deleteInsurance(insuranceId = entityId, rev = rev)
 		} else {
-			rawApi.deleteInsuranceInGroup(groupId, entityId, rev)
+			rawApi.deleteInsuranceInGroup(groupId = groupId, insuranceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteInsurances(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteInsurances(ListOfIdsAndRev(ids))
+				rawApi.deleteInsurances(insuranceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteInsurancesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteInsurancesInGroup(groupId = groupId, insuranceIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteInsurance(groupId: String?, entityId: String, rev: String): Insurance =
 		if (groupId == null) {
-			rawApi.undeleteInsurance(entityId, rev)
+			rawApi.undeleteInsurance(insuranceId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteInsuranceInGroup(groupId, entityId, rev)
+			rawApi.undeleteInsuranceInGroup(groupId = groupId, insuranceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteInsurances(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<Insurance> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteInsurances(ListOfIdsAndRev(ids))
+				rawApi.undeleteInsurances(insuranceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteInsurancesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteInsurancesInGroup(groupId = groupId, insuranceIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeInsurance(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeInsurance(entityId, rev)
+			rawApi.purgeInsurance(insuranceId = entityId, rev = rev)
 		} else {
-			rawApi.purgeInsuranceInGroup(groupId, entityId, rev)
+			rawApi.purgeInsuranceInGroup(groupId = groupId, insuranceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeInsurances(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeInsurances(ListOfIdsAndRev(ids))
+				rawApi.purgeInsurances(insuranceIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeInsurancesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeInsurancesInGroup(groupId = groupId, insuranceIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doMatchInsurancesBy(groupId: String?, filter: BaseFilterOptions<Insurance>) =
 		if (groupId == null) {
-			rawApi.matchInsurancesBy(mapInsuranceFilterOptions(filter, config))
+			rawApi.matchInsurancesBy(filter = mapInsuranceFilterOptions(filter, config))
 		} else {
-			rawApi.matchInsurancesBy(groupId, mapInsuranceFilterOptions(filter, config, groupId))
+			rawApi.matchInsurancesBy(groupId = groupId, filter = mapInsuranceFilterOptions(filter, config, groupId))
 		}.successBody()
 
 	protected suspend fun doMatchInsurancesBySorted(groupId: String?, filter: BaseSortableFilterOptions<Insurance>) =
@@ -184,10 +184,10 @@ internal class InsuranceApiImpl(
 		doPurgeInsurances(groupId = null, entityIds = entityIds)
 
 	override suspend fun listInsurancesByCode(insuranceCode: String) =
-		rawApi.listInsurancesByCode(insuranceCode).successBody()
+		rawApi.listInsurancesByCode(insuranceCode = insuranceCode).successBody()
 
 	override suspend fun listInsurancesByName(insuranceName: String) =
-		rawApi.listInsurancesByName(insuranceName).successBody()
+		rawApi.listInsurancesByName(insuranceName = insuranceName).successBody()
 
 	override suspend fun matchInsurancesBy(filter: BaseFilterOptions<Insurance>): List<String> =
 		doMatchInsurancesBy(groupId = null, filter = filter)

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/InvoiceApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/InvoiceApiImpl.kt
@@ -98,9 +98,9 @@ private abstract class AbstractInvoiceBasicFlavouredApi<E : Invoice>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createInvoice(encrypted)
+			rawApi.createInvoice(invoiceDto = encrypted)
 		} else {
-			rawApi.createInvoiceInGroup(groupId, encrypted)
+			rawApi.createInvoiceInGroup(groupId = groupId, invoiceDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -109,9 +109,9 @@ private abstract class AbstractInvoiceBasicFlavouredApi<E : Invoice>(
 	protected suspend fun doCreateInvoices(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { invoices ->
 		val encrypted = validateAndMaybeEncrypt(groupId, invoices)
 		return if (groupId == null) {
-			rawApi.createInvoices(encrypted)
+			rawApi.createInvoices(invoiceDtos = encrypted)
 		} else {
-			rawApi.createInvoicesInGroup(groupId, encrypted)
+			rawApi.createInvoicesInGroup(groupId = groupId, invoiceDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -119,16 +119,16 @@ private abstract class AbstractInvoiceBasicFlavouredApi<E : Invoice>(
 
 	protected suspend fun doUndeleteInvoice(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteInvoice(entityId, rev)
+			rawApi.undeleteInvoice(invoiceId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteInvoiceInGroup(groupId, entityId, rev)
+			rawApi.undeleteInvoiceInGroup(groupId = groupId, invoiceId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteInvoices(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteInvoices(ListOfIdsAndRev(ids))
+			rawApi.undeleteInvoices(invoiceIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteInvoicesInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteInvoicesInGroup(groupId = groupId, invoiceIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -136,18 +136,18 @@ private abstract class AbstractInvoiceBasicFlavouredApi<E : Invoice>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyInvoice(encrypted)
+			rawApi.modifyInvoice(invoiceDto = encrypted)
 		} else {
-			rawApi.modifyInvoiceInGroup(groupId, encrypted)
+			rawApi.modifyInvoiceInGroup(groupId = groupId, invoiceDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyInvoices(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { invoices ->
 		val encrypted = validateAndMaybeEncrypt(groupId, invoices)
 		return if (groupId == null) {
-			rawApi.modifyInvoices(encrypted)
+			rawApi.modifyInvoices(invoiceDtos = encrypted)
 		} else {
-			rawApi.modifyInvoicesInGroup(groupId, encrypted)
+			rawApi.modifyInvoicesInGroup(groupId = groupId, invoiceDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -155,16 +155,16 @@ private abstract class AbstractInvoiceBasicFlavouredApi<E : Invoice>(
 
 	protected suspend fun doGetInvoice(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getInvoice(entityId)
+			rawApi.getInvoice(invoiceId = entityId)
 		} else {
 			rawApi.getInvoiceInGroup(groupId = groupId, invoiceId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	suspend fun doGetInvoices(groupId: String?, entityIds: List<String>) = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getInvoices(ListOfIds(ids))
+			rawApi.getInvoices(invoiceIds = ListOfIds(ids))
 		} else {
-			rawApi.getInvoicesInGroup(groupId, ListOfIds(ids))
+			rawApi.getInvoicesInGroup(groupId = groupId, invoiceIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/MaintenanceTaskApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/MaintenanceTaskApiImpl.kt
@@ -55,25 +55,30 @@ private abstract class AbstractMaintenanceTaskBasicFlavouredApi<E : MaintenanceT
 	override suspend fun createMaintenanceTask(entity: E): E {
 		require(entity.securityMetadata != null) { "Entity must have security metadata initialized. Make sure to use the `withEncryptionMetadata` method." }
 		return rawApi.createMaintenanceTask(
-			validateAndMaybeEncrypt(null, entity)
+			maintenanceTaskDto = validateAndMaybeEncrypt(null, entity)
 		).successBody().let {
 			maybeDecrypt(null, it)
 		}
 	}
 
 	override suspend fun undeleteMaintenanceTaskById(id: String, rev: String): E =
-		rawApi.undeleteMaintenanceTask(id, rev).successBodyOrThrowRevisionConflict().let { maybeDecrypt(null, it) }
+		rawApi.undeleteMaintenanceTask(maintenanceTaskId = id, rev = rev)
+			.successBodyOrThrowRevisionConflict()
+			.let { maybeDecrypt(null, it) }
 
 	override suspend fun modifyMaintenanceTask(entity: E): E =
-		rawApi.modifyMaintenanceTask(validateAndMaybeEncrypt(null, entity)).successBodyOrThrowRevisionConflict().let { maybeDecrypt(null, it) }
+		rawApi.modifyMaintenanceTask(maintenanceTaskDto = validateAndMaybeEncrypt(null, entity))
+			.successBodyOrThrowRevisionConflict()
+			.let { maybeDecrypt(null, it) }
 
 
 	override suspend fun getMaintenanceTask(entityId: String): E? =
-		rawApi.getMaintenanceTask(entityId).successBodyOrNull404()?.let {
+		rawApi.getMaintenanceTask(maintenanceTaskId = entityId).successBodyOrNull404()?.let {
 			maybeDecrypt(null, it)
 		}
 
-	override suspend fun getMaintenanceTasks(entityIds: List<String>): List<E> = rawApi.getMaintenanceTasks(ListOfIds(entityIds)).successBody().let { maybeDecrypt(it) }
+	override suspend fun getMaintenanceTasks(entityIds: List<String>): List<E> =
+		rawApi.getMaintenanceTasks(ids = ListOfIds(entityIds)).successBody().let { maybeDecrypt(it) }
 }
 
 @InternalIcureApi
@@ -97,7 +102,7 @@ private abstract class AbstractMaintenanceTaskFlavouredApi<E : MaintenanceTask>(
 			delegates.keyAsLocalDataOwnerReferences(),
 			true,
 			{ getMaintenanceTask(it) ?: throw NotFoundException("MaintenanceTask $it not found") },
-			{ maybeDecrypt(null, rawApi.bulkShare(it).successBody()) }
+			{ maybeDecrypt(null, rawApi.bulkShare(request = it).successBody()) }
 		).updatedEntityOrThrow()
 
 	override suspend fun filterMaintenanceTasksBySorted(filter: SortableFilterOptions<MaintenanceTask>): PaginatedListIterator<E> =
@@ -105,11 +110,13 @@ private abstract class AbstractMaintenanceTaskFlavouredApi<E : MaintenanceTask>(
 
 	override suspend fun filterMaintenanceTasksBy(filter: FilterOptions<MaintenanceTask>): PaginatedListIterator<E> =
 		IdsPageIterator(
-			rawApi.matchMaintenanceTasksBy(mapMaintenanceTaskFilterOptions(
-				filter,
-				config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
-				config.crypto.entity
-			)).successBody(),
+			rawApi.matchMaintenanceTasksBy(
+				filter = mapMaintenanceTaskFilterOptions(
+					filter,
+					config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
+					config.crypto.entity
+				)
+			).successBody(),
 			this::getMaintenanceTasks
 		)
 }
@@ -120,21 +127,21 @@ private class AbstractMaintenanceTaskBasicFlavourlessApi(val rawApi: RawMaintena
 
 	@Deprecated("Deletion without rev is unsafe")
 	override suspend fun deleteMaintenanceTaskUnsafe(entityId: String): DocIdentifier =
-		rawApi.deleteMaintenanceTask(entityId).successBodyOrThrowRevisionConflict()
+		rawApi.deleteMaintenanceTask(maintenanceTaskId = entityId).successBodyOrThrowRevisionConflict()
 
 	@Deprecated("Deletion without rev is unsafe")
 	override suspend fun deleteMaintenanceTasksUnsafe(entityIds: List<String>): List<DocIdentifier> =
-		rawApi.deleteMaintenanceTasks(ListOfIds(entityIds)).successBody()
+		rawApi.deleteMaintenanceTasks(maintenanceTaskIds = ListOfIds(entityIds)).successBody()
 
 	override suspend fun deleteMaintenanceTaskById(entityId: String, rev: String): DocIdentifier =
-		rawApi.deleteMaintenanceTask(entityId, rev).successBodyOrThrowRevisionConflict()
+		rawApi.deleteMaintenanceTask(maintenanceTaskId = entityId, rev = rev).successBodyOrThrowRevisionConflict()
 
 	override suspend fun purgeMaintenanceTaskById(id: String, rev: String) {
-		rawApi.purgeMaintenanceTask(id, rev).successBodyOrThrowRevisionConflict()
+		rawApi.purgeMaintenanceTask(maintenanceTaskId = id, rev = rev).successBodyOrThrowRevisionConflict()
 	}
 
 	override suspend fun deleteMaintenanceTasksByIds(entityIds: List<StoredDocumentIdentifier>): List<DocIdentifier> =
-		rawApi.deleteMaintenanceTasksWithRev(ListOfIdsAndRev(entityIds)).successBody()
+		rawApi.deleteMaintenanceTasksWithRev(maintenanceTaskIds = ListOfIdsAndRev(entityIds)).successBody()
 }
 
 @InternalIcureApi
@@ -336,11 +343,13 @@ internal class MaintenanceTaskApiImpl(
 		matchMaintenanceTasksBy(filter)
 
 	override suspend fun matchMaintenanceTasksBy(filter: FilterOptions<MaintenanceTask>): List<String> =
-		rawApi.matchMaintenanceTasksBy(mapMaintenanceTaskFilterOptions(
-			filter,
-			config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
-			config.crypto.entity
-		)).successBody()
+		rawApi.matchMaintenanceTasksBy(
+			filter = mapMaintenanceTaskFilterOptions(
+				filter,
+				config.crypto.dataOwnerApi.getCurrentDataOwnerId(),
+				config.crypto.entity
+			)
+		).successBody()
 }
 
 @InternalIcureApi
@@ -374,11 +383,13 @@ internal class MaintenanceTaskBasicApiImpl(
 		matchMaintenanceTasksBy(filter)
 
 	override suspend fun matchMaintenanceTasksBy(filter: BaseFilterOptions<MaintenanceTask>): List<String> =
-		rawApi.matchMaintenanceTasksBy(mapMaintenanceTaskFilterOptions(
-			filter,
-			null,
-			null
-		)).successBody()
+		rawApi.matchMaintenanceTasksBy(
+			filter = mapMaintenanceTaskFilterOptions(
+				filter,
+				null,
+				null
+			)
+		).successBody()
 
 	override suspend fun subscribeToEvents(
 		events: Set<SubscriptionEventType>,

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/MessageApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/MessageApiImpl.kt
@@ -100,7 +100,7 @@ private suspend fun RawMessageApi.doMatchMessagesBy(
 ): List<String> =
 	if (groupId == null) {
 		matchMessagesBy(
-			mapMessageFilterOptions(
+			filter = mapMessageFilterOptions(
 				filter,
 				config,
 				requestGroup = null
@@ -135,9 +135,9 @@ private abstract class AbstractMessageBasicFlavouredApi<E : Message>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createMessage(encrypted)
+			rawApi.createMessage(messageDto = encrypted)
 		} else {
-			rawApi.createMessageInGroup(groupId, encrypted)
+			rawApi.createMessageInGroup(groupId = groupId, messageDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -146,9 +146,9 @@ private abstract class AbstractMessageBasicFlavouredApi<E : Message>(
 	protected suspend fun doCreateMessages(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { messages ->
 		val encrypted = validateAndMaybeEncrypt(groupId, messages)
 		return if (groupId == null) {
-			rawApi.createMessages(encrypted)
+			rawApi.createMessages(messageDtos = encrypted)
 		} else {
-			rawApi.createMessagesInGroup(groupId, encrypted)
+			rawApi.createMessagesInGroup(groupId = groupId, messageDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -156,16 +156,16 @@ private abstract class AbstractMessageBasicFlavouredApi<E : Message>(
 
 	protected suspend fun doUndeleteMessage(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteMessage(entityId, rev)
+			rawApi.undeleteMessage(messageId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteMessageInGroup(groupId, entityId, rev)
+			rawApi.undeleteMessageInGroup(groupId = groupId, messageId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteMessages(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteMessages(ListOfIdsAndRev(ids))
+			rawApi.undeleteMessages(messageIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteMessagesInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteMessagesInGroup(groupId = groupId, messageIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -173,18 +173,18 @@ private abstract class AbstractMessageBasicFlavouredApi<E : Message>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyMessage(encrypted)
+			rawApi.modifyMessage(messageDto = encrypted)
 		} else {
-			rawApi.modifyMessageInGroup(groupId, encrypted)
+			rawApi.modifyMessageInGroup(groupId = groupId, messageDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyMessages(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { messages ->
 		val encrypted = validateAndMaybeEncrypt(groupId, messages)
 		return if (groupId == null) {
-			rawApi.modifyMessages(encrypted)
+			rawApi.modifyMessages(messageDtos = encrypted)
 		} else {
-			rawApi.modifyMessagesInGroup(groupId, encrypted)
+			rawApi.modifyMessagesInGroup(groupId = groupId, messageDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -192,16 +192,16 @@ private abstract class AbstractMessageBasicFlavouredApi<E : Message>(
 
 	protected suspend fun doGetMessage(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getMessage(entityId)
+			rawApi.getMessage(messageId = entityId)
 		} else {
 			rawApi.getMessageInGroup(groupId = groupId, messageId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	suspend fun doGetMessages(groupId: String?, entityIds: List<String>) = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getMessages(ListOfIds(ids))
+			rawApi.getMessages(messageIds = ListOfIds(ids))
 		} else {
-			rawApi.getMessagesInGroup(groupId, ListOfIds(ids))
+			rawApi.getMessagesInGroup(groupId = groupId, messageIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 }
@@ -223,7 +223,7 @@ private class MessageBasicFlavouredApiImpl<E : Message>(
 	override suspend fun createMessageInTopic(entity: E): E {
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(null, entity)
-		return rawApi.createMessageInTopic(encrypted).successBody().let {
+		return rawApi.createMessageInTopic(messageDto = encrypted).successBody().let {
 			maybeDecrypt(null, it)
 		}
 	}
@@ -249,7 +249,9 @@ private class MessageBasicFlavouredApiImpl<E : Message>(
 		time: Long?,
 		readStatus: Boolean,
 		userId: String?,
-	) = rawApi.setMessagesReadStatus(MessagesReadStatusUpdate(entityIds, time, readStatus, userId)).successBody().let { maybeDecrypt(null, it) }
+	) = rawApi.setMessagesReadStatus(
+		`data` = MessagesReadStatusUpdate(entityIds, time, readStatus, userId)
+	).successBody().let { maybeDecrypt(null, it) }
 }
 
 @InternalIcureApi
@@ -324,9 +326,9 @@ private abstract class AbstractMessageFlavouredApi<E : Message>(
 				maybeDecrypt(
 					entityGroupId,
 					if (entityGroupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, entityGroupId).successBody()
+						rawApi.bulkShare(request = it, groupId = entityGroupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -412,34 +414,34 @@ private abstract class AbstractMessageBasicFlavourless(
 
 	protected suspend fun doDeleteMessage(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteMessage(entityId, rev)
+			rawApi.deleteMessage(messageId = entityId, rev = rev)
 		} else {
-			rawApi.deleteMessageInGroup(groupId, entityId, rev)
+			rawApi.deleteMessageInGroup(groupId = groupId, messageId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteMessages(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteMessagesWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteMessagesWithRev(messageIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteMessagesInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteMessagesInGroup(groupId = groupId, messageIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeMessage(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeMessage(entityId, rev)
+			rawApi.purgeMessage(messageId = entityId, rev = rev)
 		} else {
-			rawApi.purgeMessageInGroup(groupId, entityId, rev)
+			rawApi.purgeMessageInGroup(groupId = groupId, messageId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeMessages(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeMessages(ListOfIdsAndRev(ids))
+				rawApi.purgeMessages(messageIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeMessagesInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeMessagesInGroup(groupId = groupId, messageIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PatientApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PatientApiImpl.kt
@@ -121,7 +121,7 @@ private suspend fun RawPatientApi.doMatchPatientsBy(
 ): List<String> =
 	if (groupId == null) {
 		matchPatientsBy(
-			mapPatientFilterOptions(
+			filter = mapPatientFilterOptions(
 				filter,
 				config,
 				requestGroup = null
@@ -156,9 +156,9 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 		requireIsValidForCreation(patient)
 		val encrypted = validateAndMaybeEncrypt(groupId, patient)
 		return if (groupId == null) {
-			rawApi.createPatient(encrypted)
+			rawApi.createPatient(p = encrypted)
 		} else {
-			rawApi.createPatientInGroup(groupId, encrypted)
+			rawApi.createPatientInGroup(groupId = groupId, patientDto = encrypted)
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -168,24 +168,24 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 	): List<E> = skipRequestOnEmptyList(patients) { entities ->
 		val encrypted = validateAndMaybeEncrypt(groupId, entities)
 		if (groupId == null) {
-			rawApi.createPatientsFull(encrypted)
+			rawApi.createPatientsFull(patientDtos = encrypted)
 		} else {
-			rawApi.createPatientsInGroupFull(groupId, encrypted)
+			rawApi.createPatientsInGroupFull(groupId = groupId, patientDtos = encrypted)
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doUndeletePatient(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeletePatient(entityId, rev)
+			rawApi.undeletePatient(patientId = entityId, rev = rev)
 		} else {
-			rawApi.undeletePatientInGroup(groupId, entityId, rev)
+			rawApi.undeletePatientInGroup(groupId = groupId, patientId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeletePatients(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeletePatients(ListOfIdsAndRev(ids))
+			rawApi.undeletePatients(ids = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeletePatientsInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeletePatientsInGroup(groupId = groupId, ids = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -193,9 +193,9 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyPatient(encrypted)
+			rawApi.modifyPatient(patientDto = encrypted)
 		} else {
-			rawApi.modifyPatientInGroup(groupId, encrypted)
+			rawApi.modifyPatientInGroup(groupId = groupId, patientDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -205,9 +205,9 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 	): List<E> = skipRequestOnEmptyList(patients) { entities ->
 		val encrypted = validateAndMaybeEncrypt(groupId, entities)
 		if (groupId == null) {
-			rawApi.modifyPatientsFull(encrypted)
+			rawApi.modifyPatientsFull(patientDtos = encrypted)
 		} else {
-			rawApi.modifyPatientsInGroupFull(groupId, encrypted)
+			rawApi.modifyPatientsInGroupFull(groupId = groupId, patientDtos = encrypted)
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -216,7 +216,7 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 
 	protected suspend fun doGetEncryptedPatient(groupId: String?, entityId: String): EncryptedPatient? =
 		if (groupId == null) {
-			rawApi.getPatient(entityId)
+			rawApi.getPatient(patientId = entityId)
 		} else {
 			rawApi.getPatientInGroup(groupId = groupId, patientId = entityId)
 		}.successBodyOrNull404()
@@ -250,9 +250,9 @@ private abstract class AbstractPatientBasicFlavouredApi<E : Patient>(
 	suspend fun doGetPatients(groupId: String?, patientIds: List<String>) =
 		skipRequestOnEmptyList(patientIds) { ids ->
 			if (groupId == null) {
-				rawApi.getPatients(ListOfIds(ids))
+				rawApi.getPatients(patientIds = ListOfIds(ids))
 			} else {
-				rawApi.getPatientsInGroup(groupId, ListOfIds(ids))
+				rawApi.getPatientsInGroup(groupId = groupId, patientIds = ListOfIds(ids))
 			}.successBody().let {
 				maybeDecrypt(groupId, it)
 			}
@@ -386,9 +386,9 @@ private abstract class AbstractPatientFlavouredApi<E : Patient>(
 				maybeDecrypt(
 					groupId,
 					if (groupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, groupId).successBody()
+						rawApi.bulkShare(request = it, groupId = groupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()
@@ -402,7 +402,7 @@ private abstract class AbstractPatientFlavouredApi<E : Patient>(
 			patient,
 			EntityWithEncryptionMetadataTypeName.Patient,
 			{ doGetPatient(groupId, it) ?: throw NotFoundException("Patient $it not found") },
-			{ maybeDecrypt(null, rawApi.bulkShare(it).successBody()) }
+			{ maybeDecrypt(null, rawApi.bulkShare(request = it).successBody()) }
 		) ?: patient
 	}
 
@@ -487,34 +487,34 @@ private abstract class AbstractPatientBasicFlavourless(
 
 	protected suspend fun doDeletePatient(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deletePatient(entityId, rev)
+			rawApi.deletePatient(patientId = entityId, rev = rev)
 		} else {
-			rawApi.deletePatientInGroup(groupId, entityId, rev)
+			rawApi.deletePatientInGroup(groupId = groupId, patientId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeletePatients(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deletePatientsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deletePatientsWithRev(patientIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deletePatientsWithRevInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deletePatientsWithRevInGroup(groupId = groupId, patientIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgePatient(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgePatient(entityId, rev)
+			rawApi.purgePatient(patientId = entityId, rev = rev)
 		} else {
-			rawApi.purgePatientInGroup(groupId, entityId, rev)
+			rawApi.purgePatientInGroup(groupId = groupId, patientId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgePatients(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgePatients(ListOfIdsAndRev(ids))
+				rawApi.purgePatients(patientIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgePatientsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgePatientsInGroup(groupId = groupId, patientIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
@@ -789,7 +789,7 @@ private class PatientApiImpl(
 
 			val retrievedHealthElements = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
 				val heIds = rawHealthElementApi.listHealthElementIdsByDataOwnerPatientOpeningDate(dataOwnerId = doId, secretPatientKeys = ListOfIds(delSecKeys)).successBody()
-				rawHealthElementApi.listHealthElementsDelegationsStubById(ListOfIds(heIds)).successBody()
+				rawHealthElementApi.listHealthElementsDelegationsStubById(healthElementIds = ListOfIds(heIds)).successBody()
 			}
 			val shareHealthElementsResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedHealthElements,
@@ -798,72 +798,72 @@ private class PatientApiImpl(
 					it.contains(ShareAllPatientDataOptions.Tag.All)
 						|| it.contains(ShareAllPatientDataOptions.Tag.MedicalInformation)
 				},
-				getEntity = { rawHealthElementApi.getHealthElement(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawHealthElementApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawHealthElementApi.getHealthElement(healthElementId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawHealthElementApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			val retrievedForms = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
 				val formIds =  rawFormApi.listFormIdsByDataOwnerPatientOpeningDate(dataOwnerId = doId, secretPatientKeys = ListOfIds(delSecKeys)).successBody()
-				rawFormApi.findFormsDelegationsStubsByIds(ListOfIds(formIds)).successBody()
+				rawFormApi.findFormsDelegationsStubsByIds(formIds = ListOfIds(formIds)).successBody()
 			}
 			val shareFormsResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedForms,
 				entitiesType = EntityWithEncryptionMetadataTypeName.Form,
 				tagsCondition = { it.contains(ShareAllPatientDataOptions.Tag.All) || it.contains(
 					ShareAllPatientDataOptions.Tag.MedicalInformation) },
-				getEntity = { rawFormApi.getForm(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawFormApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawFormApi.getForm(formId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawFormApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			val retrievedContacts = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
 				val contactIds = rawContactApi.listContactIdsByDataOwnerPatientOpeningDate(dataOwnerId = doId, secretPatientKeys = ListOfIds(delSecKeys)).successBody()
-				rawContactApi.findContactsDelegationsStubsByIds(ListOfIds(contactIds)).successBody()
+				rawContactApi.findContactsDelegationsStubsByIds(contactIds = ListOfIds(contactIds)).successBody()
 			}
 			val shareContactsResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedContacts,
 				entitiesType = EntityWithEncryptionMetadataTypeName.Contact,
 				tagsCondition = { it.contains(ShareAllPatientDataOptions.Tag.All) || it.contains(
 					ShareAllPatientDataOptions.Tag.MedicalInformation) },
-				getEntity = { rawContactApi.getContact(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawContactApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawContactApi.getContact(contactId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawContactApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			val retrievedInvoices = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
 				val invoiceIds = rawInvoiceApi.listInvoiceIdsByDataOwnerPatientInvoiceDate(dataOwnerId = doId, secretPatientKeys = ListOfIds(delSecKeys)).successBody()
-				rawInvoiceApi.listInvoicesDelegationsStubsByIds(ListOfIds(invoiceIds)).successBody()
+				rawInvoiceApi.listInvoicesDelegationsStubsByIds(invoiceIds = ListOfIds(invoiceIds)).successBody()
 			}
 			val shareInvoicesResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedInvoices,
 				entitiesType = EntityWithEncryptionMetadataTypeName.Invoice,
 				tagsCondition = { it.contains(ShareAllPatientDataOptions.Tag.All) || it.contains(
 					ShareAllPatientDataOptions.Tag.FinancialInformation) },
-				getEntity = { rawInvoiceApi.getInvoice(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawInvoiceApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawInvoiceApi.getInvoice(invoiceId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawInvoiceApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			val retrievedCalendarItems = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
-				rawCalendarItemApi.findCalendarItemsDelegationsStubsByHCPartyPatientForeignKeys(doId, delSecKeys).successBody()
+				rawCalendarItemApi.findCalendarItemsDelegationsStubsByHCPartyPatientForeignKeys(hcPartyId = doId, secretPatientKeys = delSecKeys).successBody()
 			}
 			val shareCalendarItemsResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedCalendarItems,
 				entitiesType = EntityWithEncryptionMetadataTypeName.CalendarItem,
 				tagsCondition = { it.contains(ShareAllPatientDataOptions.Tag.All) || it.contains(
 					ShareAllPatientDataOptions.Tag.MedicalInformation) },
-				getEntity = { rawCalendarItemApi.getCalendarItem(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawCalendarItemApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawCalendarItemApi.getCalendarItem(calendarItemId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawCalendarItemApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			val retrievedClassifications = findDelegationStubsForHcPartyAndParent(delegationSecretKeys.toList(), hcp.id, parentId) { doId, delSecKeys ->
 				val classificationIds = rawClassificationApi.listClassificationIdsByDataOwnerPatientCreated(dataOwnerId = doId, secretPatientKeys = ListOfIds(delSecKeys)).successBody()
-				rawClassificationApi.findClassificationsDelegationsStubsByIds(ListOfIds(classificationIds)).successBody()
+				rawClassificationApi.findClassificationsDelegationsStubsByIds(classificationIds = ListOfIds(classificationIds)).successBody()
 			}
 			val shareClassificationResult = doShareEntitiesAndUpdateStatus(
 				entities = retrievedClassifications,
 				entitiesType = EntityWithEncryptionMetadataTypeName.Classification,
 				tagsCondition = { it.contains(ShareAllPatientDataOptions.Tag.All) || it.contains(
 					ShareAllPatientDataOptions.Tag.MedicalInformation) },
-				getEntity = { rawClassificationApi.getClassification(it).successBody().asIcureStub() },
-				doShareMinimal = { params -> rawClassificationApi.bulkShareMinimal(params).successBody() }
+				getEntity = { rawClassificationApi.getClassification(classificationId = it).successBody().asIcureStub() },
+				doShareMinimal = { params -> rawClassificationApi.bulkShareMinimal(request = params).successBody() }
 			)
 
 			mapOf(
@@ -900,7 +900,7 @@ private class PatientApiImpl(
 				EntityWithEncryptionMetadataTypeName.Patient,
 				true,
 				{ getPatient(it) ?: throw NotFoundException("Patient $it not found") },
-				{ params -> rawApi.bulkShareMinimal(params).successBody() }
+				{ params -> rawApi.bulkShareMinimal(request = params).successBody() }
 			)
 			ShareAllPatientDataOptions.EntityResult(
 				success = result.updateErrors.isEmpty(),
@@ -1125,10 +1125,10 @@ private class PatientApiImpl(
 					}).keyAsLocalDataOwnerReferences(),
 					autoRetry = false, // Will retry with the updated entity: maybe no need to update metadata after all
 					getUpdatedEntity = { throw UnsupportedOperationException("No retry") },
-					doRequestBulkShareOrUpdate = { rawApi.bulkShare(it).successBody() },
+					doRequestBulkShareOrUpdate = { rawApi.bulkShare(request = it).successBody() },
 				)
 				if (shareResult is SimpleShareResult.Failure && shareResult.errorsDetails.all { it.shouldRetry }) {
-					val updatedSelf = rawApi.getPatient(self.id).successBody()
+					val updatedSelf = rawApi.getPatient(patientId = self.id).successBody()
 					if (updatedSelf.rev != self.rev) {
 						ensureEncryptionMetadataForSelfIsInitialized(sharingWith)
 					} else shareResult.updatedEntityOrThrow()

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PermissionApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PermissionApiImpl.kt
@@ -13,7 +13,7 @@ internal class PermissionApiImpl(
 		userId: String,
 		permissions: Permission,
 	) = rawApi.modifyUserPermissions(
-		userId,
-		permissions,
+		userId = userId,
+		permissions = permissions,
 	).successBody()
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PlaceApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PlaceApiImpl.kt
@@ -21,101 +21,101 @@ internal abstract class AbstractPlaceApi(
 	protected suspend fun doCreatePlace(groupId: String?, entity: Place): Place {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createPlace(entity)
+			rawApi.createPlace(placeDto = entity)
 		} else {
-			rawApi.createPlaceInGroup(groupId, entity)
+			rawApi.createPlaceInGroup(groupId = groupId, place = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreatePlaces(groupId: String?, entities: List<Place>): List<Place> =
 		skipRequestOnEmptyList(entities) { places ->
 			if (groupId == null) {
-				rawApi.createPlaces(places)
+				rawApi.createPlaces(placeDtos = places)
 			} else {
-				rawApi.createPlacesInGroup(groupId, places)
+				rawApi.createPlacesInGroup(groupId = groupId, placeBatch = places)
 			}.successBody()
 		}
 
 	protected suspend fun doGetPlace(groupId: String?, entityId: String): Place? =
 		if (groupId == null) {
-			rawApi.getPlace(entityId)
+			rawApi.getPlace(placeId = entityId)
 		} else {
-			rawApi.getPlaceInGroup(groupId, entityId)
+			rawApi.getPlaceInGroup(groupId = groupId, placeId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetPlaces(groupId: String?, entityIds: List<String>): List<Place> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getPlacesByIds(ListOfIds(ids))
+				rawApi.getPlacesByIds(placeIds = ListOfIds(ids))
 			} else {
-				rawApi.getPlacesInGroup(groupId, ListOfIds(ids))
+				rawApi.getPlacesInGroup(groupId = groupId, placeIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyPlace(groupId: String?, entity: Place): Place {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyPlace(entity)
+			rawApi.modifyPlace(placeDto = entity)
 		} else {
-			rawApi.modifyPlaceInGroup(groupId, entity)
+			rawApi.modifyPlaceInGroup(groupId = groupId, place = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyPlaces(groupId: String?, entities: List<Place>): List<Place> =
 		skipRequestOnEmptyList(entities) { places ->
 			if (groupId == null) {
-				rawApi.modifyPlaces(places)
+				rawApi.modifyPlaces(placeDtos = places)
 			} else {
-				rawApi.modifyPlacesInGroup(groupId, places)
+				rawApi.modifyPlacesInGroup(groupId = groupId, placeBatch = places)
 			}.successBody()
 		}
 
 	protected suspend fun doDeletePlace(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deletePlace(entityId, rev)
+			rawApi.deletePlace(placeId = entityId, rev = rev)
 		} else {
-			rawApi.deletePlaceInGroup(groupId, entityId, rev)
+			rawApi.deletePlaceInGroup(groupId = groupId, placeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeletePlaces(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deletePlacesWithRev(ListOfIdsAndRev(ids))
+				rawApi.deletePlacesWithRev(placeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deletePlacesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deletePlacesInGroup(groupId = groupId, placeIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeletePlace(groupId: String?, entityId: String, rev: String): Place =
 		if (groupId == null) {
-			rawApi.undeletePlace(entityId, rev)
+			rawApi.undeletePlace(placeId = entityId, rev = rev)
 		} else {
-			rawApi.undeletePlaceInGroup(groupId, entityId, rev)
+			rawApi.undeletePlaceInGroup(groupId = groupId, placeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeletePlaces(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<Place> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeletePlaces(ListOfIdsAndRev(ids))
+				rawApi.undeletePlaces(placeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeletePlacesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeletePlacesInGroup(groupId = groupId, placeIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgePlace(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgePlace(entityId, rev)
+			rawApi.purgePlace(placeId = entityId, rev = rev)
 		} else {
-			rawApi.purgePlaceInGroup(groupId, entityId, rev)
+			rawApi.purgePlaceInGroup(groupId = groupId, placeId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgePlaces(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgePlaces(ListOfIdsAndRev(ids))
+				rawApi.purgePlaces(placeIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgePlacesInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgePlacesInGroup(groupId = groupId, placeIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ReceiptApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ReceiptApiImpl.kt
@@ -88,9 +88,9 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createReceipt(encrypted)
+			rawApi.createReceipt(receiptDto = encrypted)
 		} else {
-			rawApi.createReceiptInGroup(groupId, encrypted)
+			rawApi.createReceiptInGroup(groupId = groupId, receiptDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -99,9 +99,9 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 	protected suspend fun doCreateReceipts(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { receipts ->
 		val encrypted = validateAndMaybeEncrypt(groupId, receipts)
 		return if (groupId == null) {
-			rawApi.createReceipts(encrypted)
+			rawApi.createReceipts(receiptDtos = encrypted)
 		} else {
-			rawApi.createReceiptsInGroup(groupId, encrypted)
+			rawApi.createReceiptsInGroup(groupId = groupId, receiptDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -109,16 +109,16 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 
 	protected suspend fun doUndeleteReceipt(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteReceipt(entityId, rev)
+			rawApi.undeleteReceipt(receiptId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteReceiptInGroup(groupId, entityId, rev)
+			rawApi.undeleteReceiptInGroup(groupId = groupId, receiptId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteReceipts(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteReceipts(ListOfIdsAndRev(ids))
+			rawApi.undeleteReceipts(receiptIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteReceiptsInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteReceiptsInGroup(groupId = groupId, receiptIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -126,18 +126,18 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyReceipt(encrypted)
+			rawApi.modifyReceipt(receiptDto = encrypted)
 		} else {
-			rawApi.modifyReceiptInGroup(groupId, encrypted)
+			rawApi.modifyReceiptInGroup(groupId = groupId, receiptDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyReceipts(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { receipts ->
 		val encrypted = validateAndMaybeEncrypt(groupId, receipts)
 		return if (groupId == null) {
-			rawApi.modifyReceipts(encrypted)
+			rawApi.modifyReceipts(receiptDtos = encrypted)
 		} else {
-			rawApi.modifyReceiptsInGroup(groupId, encrypted)
+			rawApi.modifyReceiptsInGroup(groupId = groupId, receiptDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -145,16 +145,16 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 
 	protected suspend fun doGetReceipt(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getReceipt(entityId)
+			rawApi.getReceipt(receiptId = entityId)
 		} else {
-			rawApi.getReceiptInGroup(groupId, entityId)
+			rawApi.getReceiptInGroup(groupId = groupId, receiptId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doGetReceipts(groupId: String?, entityIds: List<String>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getReceipts(ListOfIds(ids))
+			rawApi.getReceipts(receiptIds = ListOfIds(ids))
 		} else {
-			rawApi.getReceiptsInGroup(groupId, ListOfIds(ids))
+			rawApi.getReceiptsInGroup(groupId = groupId, receiptIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 }
@@ -190,7 +190,7 @@ private class ReceiptBasicFlavouredApiImpl<E : Receipt>(
 	override suspend fun getReceipts(entityIds: List<String>): List<E> = doGetReceipts(groupId = null, entityIds = entityIds)
 
 	override suspend fun listByReference(reference: String): List<E> =
-		rawApi.listByReference(reference).successBody().let { maybeDecrypt(null, it) }
+		rawApi.listByReference(ref = reference).successBody().let { maybeDecrypt(null, it) }
 }
 
 @InternalIcureApi
@@ -262,9 +262,9 @@ private abstract class AbstractReceiptFlavouredApi<E : Receipt>(
 				maybeDecrypt(
 					entitiesGroupId = entityGroupId,
 					shareResults = if (entityGroupId == null)
-						rawApi.bulkShare(it).successBody()
+						rawApi.bulkShare(request = it).successBody()
 					else
-						rawApi.bulkShare(it, entityGroupId).successBody()
+						rawApi.bulkShare(request = it, groupId = entityGroupId).successBody()
 				)
 			}
 		).updatedEntityOrThrow()

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/RoleApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/RoleApiImpl.kt
@@ -19,11 +19,11 @@ internal class RoleApiImpl(
 
 	override suspend fun getAllRoles() = rawApi.getRoles().successBody()
 
-	override suspend fun getAllRolesInGroup(groupId: String): List<Role> = rawApi.getRolesInGroup(groupId).successBody()
+	override suspend fun getAllRolesInGroup(groupId: String): List<Role> = rawApi.getRolesInGroup(groupId = groupId).successBody()
 
-	override suspend fun getRole(roleId: String): Role? = rawApi.getRole(roleId).successBodyOrNull404()
+	override suspend fun getRole(roleId: String): Role? = rawApi.getRole(roleId = roleId).successBodyOrNull404()
 
-	override suspend fun getRoles(rolesIds: List<String>): List<Role> = rawApi.getRolesByIds(ListOfIds(rolesIds)).successBody()
+	override suspend fun getRoles(rolesIds: List<String>): List<Role> = rawApi.getRolesByIds(roleIds = ListOfIds(rolesIds)).successBody()
 
 	override suspend fun createRole(
 		name: String,
@@ -58,9 +58,9 @@ internal class RoleApiImpl(
 	override suspend fun modifyRolePermissions(
 		roleId: String,
 		permissions: Set<String>,
-	): Role = rawApi.modifyRolePermissions(roleId, permissions).successBodyOrThrowRevisionConflict()
+	): Role = rawApi.modifyRolePermissions(roleId = roleId, permissions = permissions).successBodyOrThrowRevisionConflict()
 
 	override suspend fun purgeRole(roleId: String, rev: String) {
-		rawApi.purgeRole(roleId, rev).successBodyOrThrowRevisionConflict()
+		rawApi.purgeRole(roleId = roleId, rev = rev).successBodyOrThrowRevisionConflict()
 	}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/SystemApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/SystemApiImpl.kt
@@ -16,20 +16,20 @@ internal class SystemApiImpl(
 	override suspend fun updateDesignDoc(
 		entityName: String,
 		warmup: Boolean?,
-	) = rawApi.updateDesignDoc(entityName, warmup).successBody()
+	) = rawApi.updateDesignDoc(entityName = entityName, warmup = warmup).successBody()
 
-	override suspend fun resolvePatientsConflicts(limit: Int?) = rawApi.resolvePatientsConflicts(limit).successBody()
-	override suspend fun resolveContactsConflicts(limit: Int?) = rawApi.resolveContactsConflicts(limit).successBody()
-	override suspend fun resolveFormsConflicts(limit: Int?) = rawApi.resolveFormsConflicts(limit).successBody()
-	override suspend fun resolveHealthElementsConflicts(limit: Int?) = rawApi.resolveHealthElementsConflicts(limit).successBody()
-	override suspend fun resolveInvoicesConflicts(limit: Int?) = rawApi.resolveInvoicesConflicts(limit).successBody()
-	override suspend fun resolveMessagesConflicts(limit: Int?) = rawApi.resolveMessagesConflicts(limit).successBody()
+	override suspend fun resolvePatientsConflicts(limit: Int?) = rawApi.resolvePatientsConflicts(limit = limit).successBody()
+	override suspend fun resolveContactsConflicts(limit: Int?) = rawApi.resolveContactsConflicts(limit = limit).successBody()
+	override suspend fun resolveFormsConflicts(limit: Int?) = rawApi.resolveFormsConflicts(limit = limit).successBody()
+	override suspend fun resolveHealthElementsConflicts(limit: Int?) = rawApi.resolveHealthElementsConflicts(limit = limit).successBody()
+	override suspend fun resolveInvoicesConflicts(limit: Int?) = rawApi.resolveInvoicesConflicts(limit = limit).successBody()
+	override suspend fun resolveMessagesConflicts(limit: Int?) = rawApi.resolveMessagesConflicts(limit = limit).successBody()
 	override suspend fun resolveDocumentsConflicts(
 		ids: String?,
 		limit: Int?,
-	) = rawApi.resolveDocumentsConflicts(ids, limit).successBody()
+	) = rawApi.resolveDocumentsConflicts(ids = ids, limit = limit).successBody()
 
-	override suspend fun getIndexingInfoByGroup(groupId: String) = rawApi.getIndexingInfoByGroup(groupId).successBody()
-	override suspend fun getReplicatorInfo(id: String) = rawApi.getReplicatorInfo(id).successBody()
-	override suspend fun evictAllFromMap(mapName: String) = rawApi.evictAllFromMap(mapName).successBody()
+	override suspend fun getIndexingInfoByGroup(groupId: String) = rawApi.getIndexingInfoByGroup(groupId = groupId).successBody()
+	override suspend fun getReplicatorInfo(id: String) = rawApi.getReplicatorInfo(id = id).successBody()
+	override suspend fun evictAllFromMap(mapName: String) = rawApi.evictAllFromMap(mapName = mapName).successBody()
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/TopicApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/TopicApiImpl.kt
@@ -102,7 +102,7 @@ private suspend fun RawTopicApi.doMatchTopicsBy(
 ): List<String> =
 	if (groupId == null) {
 		matchTopicsBy(
-			mapTopicFilterOptions(
+			filter = mapTopicFilterOptions(
 				filter,
 				config,
 				requestGroup = null
@@ -137,9 +137,9 @@ private abstract class AbstractTopicBasicFlavouredApi<E : Topic>(
 		requireIsValidForCreation(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.createTopic(encrypted)
+			rawApi.createTopic(ft = encrypted)
 		} else {
-			rawApi.createTopicInGroup(groupId, encrypted)
+			rawApi.createTopicInGroup(groupId = groupId, topicDto = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -148,9 +148,9 @@ private abstract class AbstractTopicBasicFlavouredApi<E : Topic>(
 	protected suspend fun doCreateTopics(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { topics ->
 		val encrypted = validateAndMaybeEncrypt(groupId, topics)
 		return if (groupId == null) {
-			rawApi.createTopics(encrypted)
+			rawApi.createTopics(topicDtos = encrypted)
 		} else {
-			rawApi.createTopicsInGroup(groupId, encrypted)
+			rawApi.createTopicsInGroup(groupId = groupId, topicDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -158,16 +158,16 @@ private abstract class AbstractTopicBasicFlavouredApi<E : Topic>(
 
 	protected suspend fun doUndeleteTopic(groupId: String?, entityId: String, rev: String): E =
 		if (groupId == null) {
-			rawApi.undeleteTopic(entityId, rev)
+			rawApi.undeleteTopic(topicId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteTopicInGroup(groupId, entityId, rev)
+			rawApi.undeleteTopicInGroup(groupId = groupId, topicId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 
 	protected suspend fun doUndeleteTopics(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.undeleteTopics(ListOfIdsAndRev(ids))
+			rawApi.undeleteTopics(topicIds = ListOfIdsAndRev(ids))
 		} else {
-			rawApi.undeleteTopicsInGroup(groupId, ListOfIdsAndRev(ids))
+			rawApi.undeleteTopicsInGroup(groupId = groupId, topicIds = ListOfIdsAndRev(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -175,18 +175,18 @@ private abstract class AbstractTopicBasicFlavouredApi<E : Topic>(
 		requireIsValidForModification(entity)
 		val encrypted = validateAndMaybeEncrypt(groupId, entity)
 		return if (groupId == null) {
-			rawApi.modifyTopic(encrypted)
+			rawApi.modifyTopic(topicDto = encrypted)
 		} else {
-			rawApi.modifyTopicInGroup(groupId, encrypted)
+			rawApi.modifyTopicInGroup(groupId = groupId, topicDto = encrypted)
 		}.successBodyOrThrowRevisionConflict().let { maybeDecrypt(groupId, it) }
 	}
 
 	protected suspend fun doModifyTopics(groupId: String?, entities: List<E>): List<E> = skipRequestOnEmptyList(entities) { topics ->
 		val encrypted = validateAndMaybeEncrypt(groupId, topics)
 		return if (groupId == null) {
-			rawApi.modifyTopics(encrypted)
+			rawApi.modifyTopics(topicDtos = encrypted)
 		} else {
-			rawApi.modifyTopicsInGroup(groupId, encrypted)
+			rawApi.modifyTopicsInGroup(groupId = groupId, topicDtos = encrypted)
 		}.successBody().let {
 			maybeDecrypt(groupId, it)
 		}
@@ -194,16 +194,16 @@ private abstract class AbstractTopicBasicFlavouredApi<E : Topic>(
 
 	protected suspend fun doGetTopic(groupId: String?, entityId: String): E? =
 		if (groupId == null) {
-			rawApi.getTopic(entityId)
+			rawApi.getTopic(topicId = entityId)
 		} else {
-			rawApi.getTopicInGroup(groupId, entityId)
+			rawApi.getTopicInGroup(groupId = groupId, topicId = entityId)
 		}.successBodyOrNull404()?.let { maybeDecrypt(groupId, it) }
 
 	suspend fun doGetTopics(groupId: String?, entityIds: List<String>): List<E> = skipRequestOnEmptyList(entityIds) { ids ->
 		if (groupId == null) {
-			rawApi.getTopics(ListOfIds(ids))
+			rawApi.getTopics(topicIds = ListOfIds(ids))
 		} else {
-			rawApi.getTopicsInGroup(groupId, ListOfIds(ids))
+			rawApi.getTopicsInGroup(groupId = groupId, topicIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
 
@@ -240,11 +240,11 @@ private class TopicBasicFlavouredApiImpl<E : Topic>(
 	override suspend fun getTopics(entityIds: List<String>): List<E> = doGetTopics(groupId = null, entityIds = entityIds)
 
 	override suspend fun addParticipant(entityId: String, dataOwnerId: String, topicRole: TopicRole): E =
-		rawApi.addParticipant(entityId, AddParticipant(dataOwnerId, topicRole))
+		rawApi.addParticipant(topicId = entityId, request = AddParticipant(dataOwnerId, topicRole))
 			.successBody().let { maybeDecrypt(entitiesGroupId = null, entity = it) }
 
 	override suspend fun removeParticipant(entityId: String, dataOwnerId: String): E =
-		rawApi.removeParticipant(entityId, RemoveParticipant(dataOwnerId))
+		rawApi.removeParticipant(topicId = entityId, request = RemoveParticipant(dataOwnerId))
 			.successBody().let { maybeDecrypt(entitiesGroupId = null, entity = it) }
 }
 
@@ -317,9 +317,9 @@ private abstract class AbstractTopicFlavouredApi<E : Topic>(
 			maybeDecrypt(
 				entityGroupId,
 				if (entityGroupId == null)
-					rawApi.bulkShare(it).successBody()
+					rawApi.bulkShare(request = it).successBody()
 				else
-					rawApi.bulkShare(it, entityGroupId).successBody()
+					rawApi.bulkShare(request = it, groupId = entityGroupId).successBody()
 			)
 		}
 	).updatedEntityOrThrow()
@@ -401,34 +401,34 @@ private abstract class AbstractTopicBasicFlavourless(
 
 	protected suspend fun doDeleteTopic(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteTopic(entityId, rev)
+			rawApi.deleteTopic(topicId = entityId, rev = rev)
 		} else {
-			rawApi.deleteTopicInGroup(groupId, entityId, rev)
+			rawApi.deleteTopicInGroup(groupId = groupId, topicId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteTopics(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteTopicsWithRev(ListOfIdsAndRev(ids))
+				rawApi.deleteTopicsWithRev(topicIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteTopicsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteTopicsInGroup(groupId = groupId, topicIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 
 	protected suspend fun doPurgeTopic(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeTopic(entityId, rev)
+			rawApi.purgeTopic(topicId = entityId, rev = rev)
 		} else {
-			rawApi.purgeTopicInGroup(groupId, entityId, rev)
+			rawApi.purgeTopicInGroup(groupId = groupId, topicId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeTopics(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeTopics(ListOfIdsAndRev(ids))
+				rawApi.purgeTopics(topicIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeTopicsInGroup(groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeTopicsInGroup(groupId = groupId, topicIds = ListOfIdsAndRev(ids))
 			}.successBody().toStoredDocumentIdentifier()
 		}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/UserApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/UserApiImpl.kt
@@ -38,107 +38,107 @@ internal abstract class AbstractUserApi(
 	protected suspend fun doCreateUser(groupId: String?, entity: User): User {
 		requireIsValidForCreation(entity)
 		return if (groupId == null) {
-			rawApi.createUser(entity)
+			rawApi.createUser(userDto = entity)
 		} else {
-			rawApi.createUserInGroup(groupId, entity)
+			rawApi.createUserInGroup(groupId = groupId, userDto = entity)
 		}.successBody()
 	}
 
 	protected suspend fun doCreateUsers(groupId: String?, entities: List<User>): List<User> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.createUsers(calendarItemTypes)
+				rawApi.createUsers(userDtos = calendarItemTypes)
 			} else {
-				rawApi.createUsersInGroup(groupId, calendarItemTypes)
+				rawApi.createUsersInGroup(groupId = groupId, userDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doGetUser(groupId: String?, entityId: String): User? =
 		if (groupId == null) {
-			rawApi.getUser(entityId)
+			rawApi.getUser(userId = entityId)
 		} else {
-			rawApi.getUserInGroup(groupId, entityId)
+			rawApi.getUserInGroup(groupId = groupId, userId = entityId)
 		}.successBodyOrNull404()
 
 	protected suspend fun doGetUsers(groupId: String?, entityIds: List<String>): List<User> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.getUsers(ListOfIds(ids))
+				rawApi.getUsers(userIds = ListOfIds(ids))
 			} else {
-				rawApi.getUsersInGroup(groupId, ListOfIds(ids))
+				rawApi.getUsersInGroup(groupId = groupId, userIds = ListOfIds(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doModifyUser(groupId: String?, entity: User): User {
 		requireIsValidForModification(entity)
 		return if (groupId == null) {
-			rawApi.modifyUser(entity)
+			rawApi.modifyUser(userDto = entity)
 		} else {
-			rawApi.modifyUserInGroup(groupId, entity)
+			rawApi.modifyUserInGroup(groupId = groupId, userDto = entity)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doModifyUsers(groupId: String?, entities: List<User>): List<User> =
 		skipRequestOnEmptyList(entities) { calendarItemTypes ->
 			if (groupId == null) {
-				rawApi.modifyUsers(calendarItemTypes)
+				rawApi.modifyUsers(userDtos = calendarItemTypes)
 			} else {
-				rawApi.modifyUsersInGroup(groupId, calendarItemTypes)
+				rawApi.modifyUsersInGroup(groupId = groupId, userDtos = calendarItemTypes)
 			}.successBody()
 		}
 
 	protected suspend fun doDeleteUser(groupId: String?, entityId: String, rev: String): StoredDocumentIdentifier =
 		if (groupId == null) {
-			rawApi.deleteUser(entityId, rev)
+			rawApi.deleteUser(userId = entityId, rev = rev)
 		} else {
-			rawApi.deleteUserInGroup(groupId, entityId, rev)
+			rawApi.deleteUserInGroup(groupId = groupId, userId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict().toStoredDocumentIdentifier()
 
 	protected suspend fun doDeleteUsers(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.deleteUsers(ListOfIdsAndRev(ids))
+				rawApi.deleteUsers(userIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.deleteUsersInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.deleteUsersInGroup(groupId = groupId, userIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doUndeleteUser(groupId: String?, entityId: String, rev: String): User =
 		if (groupId == null) {
-			rawApi.undeleteUser(entityId, rev)
+			rawApi.undeleteUser(userId = entityId, rev = rev)
 		} else {
-			rawApi.undeleteUserInGroup(groupId, entityId, rev)
+			rawApi.undeleteUserInGroup(groupId = groupId, userId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 
 	protected suspend fun doUndeleteUsers(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<User> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.undeleteUsers(ListOfIdsAndRev(ids))
+				rawApi.undeleteUsers(userIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.undeleteUsersInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.undeleteUsersInGroup(groupId = groupId, userIds = ListOfIdsAndRev(ids))
 			}.successBody()
 		}
 
 	protected suspend fun doPurgeUser(groupId: String?, entityId: String, rev: String) {
 		if (groupId == null) {
-			rawApi.purgeUser(entityId, rev)
+			rawApi.purgeUser(userId = entityId, rev = rev)
 		} else {
-			rawApi.purgeUserInGroup(groupId, entityId, rev)
+			rawApi.purgeUserInGroup(groupId = groupId, userId = entityId, rev = rev)
 		}.successBodyOrThrowRevisionConflict()
 	}
 
 	protected suspend fun doPurgeUsers(groupId: String?, entityIds: List<StoredDocumentIdentifier>): List<StoredDocumentIdentifier> =
 		skipRequestOnEmptyList(entityIds) { ids ->
 			if (groupId == null) {
-				rawApi.purgeUsers(ListOfIdsAndRev(ids))
+				rawApi.purgeUsers(userIds = ListOfIdsAndRev(ids))
 			} else {
-				rawApi.purgeUsersInGroup(groupId = groupId, ListOfIdsAndRev(ids))
+				rawApi.purgeUsersInGroup(groupId = groupId, userIds = ListOfIdsAndRev(ids))
 			}.successBody().map { it.toStoredDocumentIdentifier() }
 		}
 
 	protected suspend fun doMatchUsersBy(groupId: String?, filter: BaseFilterOptions<User>): List<String> =
 		if (groupId == null) {
-			rawApi.matchUsersBy(mapUserFilterOptions(filter))
+			rawApi.matchUsersBy(filter = mapUserFilterOptions(filter))
 		} else {
 			rawApi.matchUsersInGroupBy(groupId = groupId, filter = mapUserFilterOptions(filter))
 		}.successBody()
@@ -169,13 +169,13 @@ internal class UserApiImpl(
 
 	override suspend fun getUsers(userIds: List<String>) = doGetUsers(groupId = null, entityIds = userIds)
 
-	override suspend fun getUserByEmail(email: String) = rawApi.getUserByEmail(email).successBodyOrNull404()
+	override suspend fun getUserByEmail(email: String) = rawApi.getUserByEmail(email = email).successBodyOrNull404()
 
-	override suspend fun getUserByPhoneNumber(phoneNumber: String) = rawApi.getUserByPhoneNumber(phoneNumber).successBodyOrNull404()
+	override suspend fun getUserByPhoneNumber(phoneNumber: String) = rawApi.getUserByPhoneNumber(phoneNumber = phoneNumber).successBodyOrNull404()
 
-	override suspend fun findByHcpartyId(id: String) = rawApi.findByHcpartyId(id).successBody()
+	override suspend fun findByHcpartyId(id: String) = rawApi.findByHcpartyId(id = id).successBody()
 
-	override suspend fun findByPatientId(id: String) = rawApi.findByPatientId(id).successBody()
+	override suspend fun findByPatientId(id: String) = rawApi.findByPatientId(id = id).successBody()
 
 	override suspend fun modifyUser(user: User) = doModifyUser(groupId = null, entity = user)
 
@@ -184,19 +184,19 @@ internal class UserApiImpl(
 		return doModifyUsers(groupId = null, entities = users)
 	}
 
-	override suspend fun assignHealthcareParty(healthcarePartyId: String) = rawApi.assignHealthcareParty(healthcarePartyId).successBody()
+	override suspend fun assignHealthcareParty(healthcarePartyId: String) = rawApi.assignHealthcareParty(healthcarePartyId = healthcarePartyId).successBody()
 
 	override suspend fun modifyProperties(
 		userId: String,
 		properties: List<EncryptedPropertyStub>?,
-	) = rawApi.modifyProperties(userId, properties).successBody()
+	) = rawApi.modifyProperties(userId = userId, properties = properties).successBody()
 
 	override suspend fun getToken(
 		userId: String,
 		key: String,
 		tokenValidity: Long?,
 		token: String?,
-	) = rawApi.getToken(userId, key, tokenValidity, token).successBody()
+	) = rawApi.getToken(userId = userId, key = key, tokenValidity = tokenValidity, token = token).successBody()
 
 	override suspend fun matchUsersBy(filter: BaseFilterOptions<User>) =
 		doMatchUsersBy(groupId = null, filter = filter)
@@ -239,42 +239,42 @@ internal class UserApiImpl(
 	).successBodyOrThrowRevisionConflict()
 
 	override suspend fun setUserRoles(userId: String, rolesIds: List<String>) =
-		rawApi.setRolesForUser(userId, ListOfIds(rolesIds)).successBodyOrThrowRevisionConflict()
+		rawApi.setRolesForUser(userId = userId, rolesId = ListOfIds(rolesIds)).successBodyOrThrowRevisionConflict()
 
-	override suspend fun resetUserRoles(userId: String) = rawApi.resetUserRoles(userId).successBodyOrThrowRevisionConflict()
+	override suspend fun resetUserRoles(userId: String) = rawApi.resetUserRoles(userId = userId).successBodyOrThrowRevisionConflict()
 
 	override suspend fun enable2faForUser(
 		userId: String,
 		request: Enable2faRequest,
 	) {
-		rawApi.enable2faForUser(userId, request).successBody()
+		rawApi.enable2faForUser(userId = userId, request = request).successBody()
 	}
 
 	override suspend fun disable2faForUser(userId: String) {
-		rawApi.disable2faForUser(userId).successBody()
+		rawApi.disable2faForUser(userId = userId).successBody()
 	}
 
-	override suspend fun createAdminUser(user: User) = rawApi.createAdminUser(user).successBody()
+	override suspend fun createAdminUser(user: User) = rawApi.createAdminUser(userDto = user).successBody()
 
 	override suspend fun modifyUserPassword(
 		userId: String,
 		newPassword: String,
 	): User =
-		rawApi.changeUserPassword(userId, ChangeUserPasswordRequest(newPassword)).successBody()
+		rawApi.changeUserPassword(userId = userId, request = ChangeUserPasswordRequest(newPassword)).successBody()
 
 	override suspend fun modifyUserEmail(
 		userId: String,
 		newEmail: String,
 		previousEmail: String?,
 	): User =
-		rawApi.changeUserEmail(userId, newEmail, previousEmail).successBody()
+		rawApi.changeUserEmail(userId = userId, newEmail = newEmail, previousEmail = previousEmail).successBody()
 
 	override suspend fun modifyUserMobilePhone(
 		userId: String,
 		newMobilePhone: String,
 		previousMobilePhone: String?,
 	): User =
-		rawApi.changeUserMobilePhone(userId, newMobilePhone, previousMobilePhone).successBody()
+		rawApi.changeUserMobilePhone(userId = userId, newMobilePhone = newMobilePhone, previousMobilePhone = previousMobilePhone).successBody()
 
 	override suspend fun subscribeToEvents(
 		events: Set<SubscriptionEventType>,
@@ -392,8 +392,8 @@ internal class UserInGroupApiImpl(
 
 	override suspend fun setUserInheritsPermissions(user: GroupScoped<User>, value: Boolean) {
 		rawApi.setUserInheritsPermissions(
-			groupId = user.groupId,
 			userId = user.entity.id,
+			groupId = user.groupId,
 			value = value
 		).successBodyOrThrowRevisionConflict()
 	}
@@ -405,8 +405,8 @@ internal class UserInGroupApiImpl(
 	): Boolean = rawApi.setLoginIdentifiers(
 		userId = user.entity.id,
 		groupId = user.groupId,
-		identifier = identifier,
-		replaceExisting = replaceExisting
+		replaceExisting = replaceExisting,
+		identifier = identifier
 	).successBodyOrThrowRevisionConflict()
 
 	override suspend fun setUserRoles(
@@ -445,7 +445,7 @@ internal class UserInGroupApiImpl(
 		key: String,
 		token: String?,
 		tokenValidity: Long?,
-	) = rawApi.getTokenInAllGroups(userIdentifier, key, token, tokenValidity).successBody()
+	) = rawApi.getTokenInAllGroups(userIdentifier = userIdentifier, key = key, token = token, tokenValidity = tokenValidity).successBody()
 
 	override suspend fun enable2faForUser(
 		user: GroupScoped<User>,


### PR DESCRIPTION
All usages of raw api are now using the names of the parameters explicitly, to avoid inverting parameters by mistake. Some issue with existing usages have been fixed.