### PR TITLE
Make patient optional in AccessLog.withEncryptionMetadata

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/AccessLogApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/AccessLogApi.kt
@@ -396,7 +396,8 @@ interface AccessLogApi : AccessLogBasicFlavourlessApi, AccessLogFlavouredApi<Dec
 	 */
 	suspend fun withEncryptionMetadata(
 		base: DecryptedAccessLog?,
-		patient: Patient,
+		@DefaultValue("null")
+		patient: Patient? = null,
 		@DefaultValue("null")
 		user: User? = null,
 		@DefaultValue("emptyMap()")

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AccessLogApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/AccessLogApiImpl.kt
@@ -606,7 +606,7 @@ private class AccessLogApiImpl(
 
 	override suspend fun withEncryptionMetadata(
 		base: DecryptedAccessLog?,
-		patient: Patient,
+		patient: Patient?,
 		user: User?,
 		delegates: Map<String, AccessLevel>,
 		secretId: SecretIdUseOption,
@@ -615,7 +615,7 @@ private class AccessLogApiImpl(
 		doWithEncryptionMetadata(
 			entityGroupId = null,
 			base = base,
-			patientInGroup = Pair(patient, null),
+			patientInGroup = patient?.let { Pair(it, null) },
 			user = user,
 			delegates = delegates.keyAsLocalDataOwnerReferences(),
 			secretId = secretId,
@@ -643,7 +643,7 @@ private class AccessLogApiImpl(
 	private suspend fun doWithEncryptionMetadata(
 		entityGroupId: String?,
 		base: DecryptedAccessLog?,
-		patientInGroup: Pair<Patient, String?>,
+		patientInGroup: Pair<Patient, String?>?,
 		user: User?,
 		delegates: @JsMapAsObjectArray(keyEntryName = "delegate", valueEntryName = "accessLevel") Map<EntityReferenceInGroup, AccessLevel>,
 		secretId: SecretIdUseOption,
@@ -662,7 +662,7 @@ private class AccessLogApiImpl(
 	private suspend fun doWithEncryptionMetadataAndDelegates(
 		entityGroupId: String?,
 		base: DecryptedAccessLog?,
-		patientInGroup: Pair<Patient, String?>,
+		patientInGroup: Pair<Patient, String?>?,
 		user: User?,
 		delegates: @JsMapAsObjectArray(keyEntryName = "delegate", valueEntryName = "delegateOptions") Map<EntityReferenceInGroup, DelegateOptions>,
 		secretId: SecretIdUseOption,
@@ -677,7 +677,7 @@ private class AccessLogApiImpl(
 				author = base?.author ?: user?.id?.takeIf { config.autofillAuthor },
 			),
 			entityType = EntityWithEncryptionMetadataTypeName.AccessLog,
-			owningEntityDetails = patientInGroup.let { (patient, patientGroup) ->
+			owningEntityDetails = patientInGroup?.let { (patient, patientGroup) ->
 				OwningEntityDetails(
 					patientGroup,
 					patient.id,

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/DefaultEncryptedFieldsManifestTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/DefaultEncryptedFieldsManifestTest.kt
@@ -33,7 +33,6 @@ import com.icure.cardinal.sdk.model.embed.DecryptedPatientHealthCareParty
 import com.icure.cardinal.sdk.model.embed.DecryptedService
 import com.icure.cardinal.sdk.model.embed.Gender
 import com.icure.cardinal.sdk.model.embed.MhcSignatureType
-import com.icure.cardinal.sdk.model.embed.Partnership
 import com.icure.cardinal.sdk.model.embed.PartnershipStatus
 import com.icure.cardinal.sdk.model.embed.PartnershipType
 import com.icure.cardinal.sdk.model.embed.PatientHealthCarePartyType


### PR DESCRIPTION
## Summary
- `AccessLogApi.withEncryptionMetadata` now accepts a nullable `patient`, so an access log's encryption metadata can be initialized without an owning patient (e.g. for receipt attachment flows).
- Threaded the nullability through `AccessLogApiImpl` (`patientInGroup`, `doWithEncryptionMetadata`, `doWithEncryptionMetadataAndDelegates`).
- Removed an unused import in `DefaultEncryptedFieldsManifestTest.kt`.

## Test plan
- [x] `:cardinal-sdk:compileKotlinJvm` and `:cardinal-sdk:compileTestKotlinJvm` build successfully
- [x] Ran non-backend-dependent unit tests (`ContentDeserializationTest`) — pass
- [ ] Full `jvmTest` integration suite requires a live Kraken backend not available in this environment — not run here

🤖 Generated with [Claude Code](https://claude.com/claude-code)