### PR TITLE
Expose in-group receipt listing by dates and raw attachment download in ReceiptApi

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/ReceiptApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/ReceiptApi.kt
@@ -142,6 +142,11 @@ interface ReceiptBasicFlavourlessInGroupApi {
 	 */
 	suspend fun purgeReceipts(receipts: List<GroupScoped<Receipt>>): List<GroupScoped<StoredDocumentIdentifier>> =
 		purgeReceiptsByIds(receipts.map { it.toStoredDocumentIdentifier() })
+
+	/**
+	 * In-group version of [ReceiptBasicFlavourlessApi.getRawReceiptAttachment]
+	 */
+	suspend fun getRawReceiptAttachment(groupId: String, receiptId: String, attachmentId: String): ByteArray
 }
 
 /* This interface includes the API calls can be used on decrypted items if encryption keys are available *or* encrypted items if no encryption keys are available */
@@ -234,6 +239,24 @@ interface ReceiptBasicFlavouredApi<E : Receipt> {
 	suspend fun getReceipts(entityIds: List<String>): List<E>
 
 	suspend fun listByReference(reference: String): List<E>
+
+	/**
+	 * Lists the receipts created within the provided date interval (based on the receipt `created`
+	 * timestamp, both bounds inclusive). A null bound leaves that side of the interval open.
+	 * Flavoured method.
+	 * @param startDate the start of the interval (inclusive), no lower bound if null
+	 * @param endDate the end of the interval (inclusive), no upper bound if null
+	 * @param descending whether to sort the result from the most recent to the oldest
+	 * @return the receipts created within the provided interval
+	 */
+	suspend fun listReceiptsBetweenDates(
+		@DefaultValue("null")
+		startDate: Long? = null,
+		@DefaultValue("null")
+		endDate: Long? = null,
+		@DefaultValue("false")
+		descending: Boolean = false,
+	): List<E>
 }
 
 interface ReceiptBasicFlavouredInGroupApi<E : Receipt> {
@@ -288,6 +311,19 @@ interface ReceiptBasicFlavouredInGroupApi<E : Receipt> {
 	 * In-group version of [ReceiptBasicFlavouredApi.getReceipts]
 	 */
 	suspend fun getReceipts(groupId: String, entityIds: List<String>): List<GroupScoped<E>>
+
+	/**
+	 * In-group version of [ReceiptBasicFlavouredApi.listReceiptsBetweenDates]
+	 */
+	suspend fun listReceiptsBetweenDates(
+		groupId: String,
+		@DefaultValue("null")
+		startDate: Long? = null,
+		@DefaultValue("null")
+		endDate: Long? = null,
+		@DefaultValue("false")
+		descending: Boolean = false,
+	): List<GroupScoped<E>>
 }
 
 /* The extra API calls declared in this interface are the ones that can be used on encrypted or decrypted items but only when the user is a data owner */

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ReceiptApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ReceiptApiImpl.kt
@@ -160,6 +160,13 @@ private abstract class AbstractReceiptBasicFlavouredApi<E : Receipt>(
 			rawApi.getReceiptsInGroup(groupId = groupId, receiptIds = ListOfIds(ids))
 		}.successBody().let { maybeDecrypt(groupId, it) }
 	}
+
+	protected suspend fun doListReceiptsBetweenDates(groupId: String?, startDate: Long?, endDate: Long?, descending: Boolean): List<E> =
+		if (groupId == null) {
+			rawApi.listReceiptsBetweenDates(startDate = startDate, endDate = endDate, descending = descending)
+		} else {
+			rawApi.listReceiptsBetweenDatesInGroup(groupId = groupId, startDate = startDate, endDate = endDate, descending = descending)
+		}.successBody().let { maybeDecrypt(groupId, it) }
 }
 
 @InternalIcureApi
@@ -194,6 +201,9 @@ private class ReceiptBasicFlavouredApiImpl<E : Receipt>(
 
 	override suspend fun listByReference(reference: String): List<E> =
 		rawApi.listByReference(ref = reference).successBody().let { maybeDecrypt(null, it) }
+
+	override suspend fun listReceiptsBetweenDates(startDate: Long?, endDate: Long?, descending: Boolean): List<E> =
+		doListReceiptsBetweenDates(groupId = null, startDate = startDate, endDate = endDate, descending = descending)
 }
 
 @InternalIcureApi
@@ -241,6 +251,10 @@ private class ReceiptBasicFlavouredInGroupApiImpl<E : Receipt>(
 
 	override suspend fun getReceipts(groupId: String, entityIds: List<String>): List<GroupScoped<E>> =
 		doGetReceipts(groupId = groupId, entityIds = entityIds).map { GroupScoped(it, groupId) }
+
+	override suspend fun listReceiptsBetweenDates(groupId: String, startDate: Long?, endDate: Long?, descending: Boolean): List<GroupScoped<E>> =
+		doListReceiptsBetweenDates(groupId = groupId, startDate = startDate, endDate = endDate, descending = descending)
+			.map { GroupScoped(it, groupId) }
 }
 
 @InternalIcureApi
@@ -365,6 +379,9 @@ private abstract class AbstractReceiptBasicFlavourless(
 
 	suspend fun getRawReceiptAttachment(receiptId: String, attachmentId: String): ByteArray =
 		rawApi.getReceiptAttachment(receiptId = receiptId, attachmentId = attachmentId).successBody()
+
+	suspend fun getRawReceiptAttachment(groupId: String, receiptId: String, attachmentId: String): ByteArray =
+		rawApi.getReceiptAttachmentInGroup(groupId = groupId, receiptId = receiptId, attachmentId = attachmentId).successBody()
 
 	suspend fun setRawReceiptAttachment(receiptId: String, rev: String, blobType: String, attachment: ByteArray): EncryptedReceipt =
 		rawApi.setReceiptAttachment(receiptId = receiptId, blobType = blobType, rev = rev, payload = attachment).successBody()


### PR DESCRIPTION
## Summary

The raw layer already gained `listReceiptsBetweenDatesInGroup` and `getReceiptAttachmentInGroup` from the kraken-cloud codegen (icure/kraken-cloud#632). This PR exposes them in the high-level receipt API:

- `ReceiptBasicFlavouredApi.listReceiptsBetweenDates(startDate?, endDate?, descending)` — the non-group `/byCreated` endpoint previously had no high-level counterpart — plus its in-group version on `ReceiptBasicFlavouredInGroupApi`, returning `GroupScoped<E>` like its siblings.
- `ReceiptBasicFlavourlessInGroupApi.getRawReceiptAttachment(groupId, receiptId, attachmentId)` — the in-group version of the existing `getRawReceiptAttachment`.

Both flow into `ReceiptApi` / `ReceiptInGroupApi` / `ReceiptBasicApi` / `ReceiptBasicInGroupApi` through the existing flavoured/flavourless delegation, so no wiring changes were needed. Parameters carry `@DefaultValue` annotations for the wrapper generation.

## TypeScript declarations

The `.mts` declarations regenerate through the usual on-merge automation ("Update Typescript SDK on PR merge to develop") — after merge, `ReceiptInGroupApi.mts` / `ReceiptBasicInGroupApi.mts` should gain `listReceiptsBetweenDates` and `getRawReceiptAttachment`.

## Consumer

Needed by the receipts-migration service's target-group mode: sweeping and downloading legacy attachments of a group the operator's refresh token is not logged into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)