### PR TITLE
Fix inverted precondition in CalendarItem linkToPatient

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/CalendarItemApiImpl.kt
@@ -349,7 +349,7 @@ private class CalendarItemFlavouredApiImpl<E : CalendarItem>(
 		doShareWithMany(groupId = null, calendarItem, delegates.keyAsLocalDataOwnerReferences())
 
 	override suspend fun linkToPatient(calendarItem: CalendarItem, patient: Patient, shareLinkWithDelegates: Set<String>): E {
-		require(calendarItem.secretForeignKeys.isNotEmpty()) { "Calendar item ${calendarItem.id} is already linked to a patient" }
+		require(calendarItem.secretForeignKeys.isEmpty()) { "Calendar item ${calendarItem.id} is already linked to a patient" }
 		val currentDataOwnerId = dataOwnerApi.getCurrentDataOwner().successBody().dataOwner.id
 		val delegates = shareLinkWithDelegates + currentDataOwnerId
 		val secretForeignKeys = config.crypto.entity.getConfidentialSecretIdsOf(
@@ -514,7 +514,7 @@ private class CalendarItemBasicFlavourlessInGroupApiImpl(rawApi: RawCalendarItem
 	}
 
 	override suspend fun purgeCalendarItemsByIds(entityIds: List<GroupScoped<StoredDocumentIdentifier>>): List<GroupScoped<StoredDocumentIdentifier>> =
-		entityIds.mapUniqueIdentifiablesChunkedByGroup { groupId, batch -> 
+		entityIds.mapUniqueIdentifiablesChunkedByGroup { groupId, batch ->
 			doPurgeCalendarItemsByIds(groupId, batch)
 		}
 }

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/CalendarItemLinkToPatientTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/CalendarItemLinkToPatientTest.kt
@@ -1,0 +1,69 @@
+package com.icure.cardinal.sdk.api
+
+import com.icure.cardinal.sdk.CardinalSdk
+import com.icure.cardinal.sdk.model.DecryptedCalendarItem
+import com.icure.cardinal.sdk.model.DecryptedPatient
+import com.icure.cardinal.sdk.model.EntityReferenceInGroup
+import com.icure.cardinal.sdk.test.autoCancelJob
+import com.icure.cardinal.sdk.test.createHcpUser
+import com.icure.cardinal.sdk.test.initializeTestEnvironment
+import com.icure.cardinal.sdk.test.uuid
+import com.icure.cardinal.sdk.utils.DEFAULT_ENABLED
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+class CalendarItemLinkToPatientTest : StringSpec({
+	val specJob = autoCancelJob()
+
+	beforeSpec {
+		initializeTestEnvironment()
+	}
+
+	suspend fun createPatientWithApi(api: CardinalSdk): DecryptedPatient =
+		api.patient.createPatient(
+			api.patient.withEncryptionMetadata(
+				DecryptedPatient(
+					id = uuid(),
+					firstName = "John",
+					lastName = "Doe",
+				)
+			)
+		)
+
+	"Should be able to link a calendar item without a linked patient to a patient".config(enabled = DEFAULT_ENABLED) {
+		val api = createHcpUser().api(specJob)
+		val patient = createPatientWithApi(api)
+		val calendarItem = api.calendarItem.createCalendarItem(
+			api.calendarItem.withEncryptionMetadata(
+				DecryptedCalendarItem(
+					id = uuid(),
+					title = "Unlinked calendar item",
+				),
+				patient = null,
+			)
+		)
+		calendarItem.secretForeignKeys.shouldBeEmpty()
+		val linked = api.calendarItem.linkToPatient(calendarItem, patient, emptySet())
+		linked.secretForeignKeys shouldBe api.patient.getSecretIdsOf(patient).keys
+		api.calendarItem.decryptPatientIdOf(linked) shouldBe setOf(EntityReferenceInGroup(patient.id, null))
+	}
+
+	"Linking a calendar item that is already linked to a patient should fail".config(enabled = DEFAULT_ENABLED) {
+		val api = createHcpUser().api(specJob)
+		val patient = createPatientWithApi(api)
+		val calendarItem = api.calendarItem.createCalendarItem(
+			api.calendarItem.withEncryptionMetadata(
+				DecryptedCalendarItem(
+					id = uuid(),
+					title = "Linked calendar item",
+				),
+				patient,
+			)
+		)
+		shouldThrow<IllegalArgumentException> {
+			api.calendarItem.linkToPatient(calendarItem, patient, emptySet())
+		}
+	}
+})


### PR DESCRIPTION
## Summary
- `CalendarItemFlavouredApi.linkToPatient` had an inverted `require`: it demanded `secretForeignKeys.isNotEmpty()` with the message "already linked to a patient", so every *unlinked* calendar item was rejected with that error while already-linked items passed the guard. The guard now correctly requires `secretForeignKeys.isEmpty()`.
- Added `CalendarItemLinkToPatientTest` covering both behaviors: linking an unlinked calendar item succeeds (secret foreign keys populated, patient id decryptable), and linking an already-linked calendar item throws `IllegalArgumentException`.

## Test plan
- [x] New tests verified to fail against the previous (buggy) guard and pass with the fix: `./gradlew :cardinal-sdk:jvmTest --tests "com.icure.cardinal.sdk.api.CalendarItemLinkToPatientTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)