### PR TITLE
Sharing optimizations

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/PatientApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/PatientApi.kt
@@ -277,6 +277,7 @@ interface PatientBasicFlavouredApi<E : Patient> {
 	 *   Note that since the metadata is automatically updated by this method you must not change the metadata of the `mergedInto` patient
 	 *   (`delegations`, mergedInto`, ...): if there is any change between the metadata of the provided `mergedInto` patient and the stored patient this
 	 *   method will fail.
+	 * - Encryption keys WILL NOT be merged
 	 *
 	 * In case the revisions of [from] and/or [mergedInto] does not match the latest revisions for these patients in the database this
 	 * method will fail without soft-deleting the `from` patient and without updating the `into` patient with the merged content and metadata. You will
@@ -292,6 +293,11 @@ interface PatientBasicFlavouredApi<E : Patient> {
 	 * - C has no access to the encryption key of the merged patient, and has access only to the secret id which was originally from the unmerged P''
 	 *
 	 * Note that the user performing this operation must have write access to both patients.
+	 *
+	 * # Merging encrypted patients
+	 *
+	 * When merging encrypted patients make sure that you don't merge `encryptedSelf` values coming from different
+	 * patients, as that will create an undecryptable patient
 	 *
 	 * @param from the original, unmodified `from` patient. Its content will be unchanged and its metadata will be automatically updated by this method
 	 * to reflect the merge.

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PatientApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/PatientApiImpl.kt
@@ -306,7 +306,8 @@ private class PatientBasicFlavouredApiImpl<E : Patient>(
 			expectedFromRev = requireNotNull(from.rev) {
 				"From patient should have a non-null rev"
 			},
-			updatedInto = validateAndMaybeEncrypt(null, mergedInto)
+			updatedInto = validateAndMaybeEncrypt(null, mergedInto),
+			omitEncryptionKeysOfFrom = true,
 		).let {
 			maybeDecrypt(null, it.successBody())
 		}

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/EntityEncryptionServiceImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/EntityEncryptionServiceImpl.kt
@@ -25,6 +25,7 @@ import com.icure.cardinal.sdk.crypto.entities.OwningEntityDetails
 import com.icure.cardinal.sdk.crypto.entities.SdkBoundGroup
 import com.icure.cardinal.sdk.crypto.entities.SecretIdShareOptions
 import com.icure.cardinal.sdk.crypto.entities.SecretIdUseOption
+import com.icure.cardinal.sdk.crypto.entities.SecureDelegationMembersDetails
 import com.icure.cardinal.sdk.crypto.entities.SecurityMetadataType
 import com.icure.cardinal.sdk.crypto.entities.ShareMetadataBehaviour
 import com.icure.cardinal.sdk.crypto.entities.SimpleDelegateShareOptions
@@ -485,9 +486,34 @@ class EntityEncryptionServiceImpl(
 		autoRetry: Boolean,
 		getUpdatedEntity: suspend (String) -> T,
 		doRequestBulkShareOrUpdate: suspend (request: BulkShareOrUpdateMetadataParams) -> List<EntityBulkShareResult<out T>>
+	): BulkShareResult<T> = doBulkShareOrUpdateEncryptedEntityMetadata(
+		entityGroupId,
+		entitiesUpdates,
+		entitiesType,
+		autoRetry,
+		getUpdatedEntity,
+		doRequestBulkShareOrUpdate,
+		emptyMap()
+	)
+
+	/**
+	 * Same as [bulkShareOrUpdateEncryptedEntityMetadata], but allows [simpleShareOrUpdateEncryptedEntityMetadata] to
+	 * pass in the security metadata it already had to decrypt to resolve its own [SimpleDelegateShareOptions], so
+	 * that [prepareBulkShareRequests] doesn't have to decrypt everything again from scratch to figure out what each
+	 * delegate already has. Callers that don't have anything precomputed (or whose entity may have changed since,
+	 * e.g. on auto-retry) can just pass an empty map, in which case [prepareBulkShareRequests] decrypts on its own.
+	 */
+	private suspend fun <T : HasEncryptionMetadata> doBulkShareOrUpdateEncryptedEntityMetadata(
+		entityGroupId: String?,
+		entitiesUpdates: List<Pair<T, Map<EntityReferenceInGroup, DelegateShareOptions>>>,
+		entitiesType: EntityWithEncryptionMetadataTypeName,
+		autoRetry: Boolean,
+		getUpdatedEntity: suspend (String) -> T,
+		doRequestBulkShareOrUpdate: suspend (request: BulkShareOrUpdateMetadataParams) -> List<EntityBulkShareResult<out T>>,
+		precomputedDecryptedMetadata: Map<String, PerEntityDecryptedSecurityMetadata>
 	): BulkShareResult<T> {
 		val normalizedEntitiesUpdates = entitiesUpdates.map { (e, rs) -> e to rs.mapKeys { it.key.normalized(boundGroup) } }
-		val requestDetails = prepareBulkShareRequests(entityGroupId, normalizedEntitiesUpdates, entitiesType)
+		val requestDetails = prepareBulkShareRequests(entityGroupId, normalizedEntitiesUpdates, entitiesType, precomputedDecryptedMetadata)
 		val shareResult = doRequestBulkShareOrUpdate(
 			BulkShareOrUpdateMetadataParams(
 				requestDetails.requestsByEntityId.mapValues { (_, details) ->
@@ -617,9 +643,10 @@ class EntityEncryptionServiceImpl(
 		doRequestBulkShareOrUpdate: suspend (request: BulkShareOrUpdateMetadataParams) -> List<EntityBulkShareResult<out T>>
 	): SimpleShareResult<T> {
 		val normalizedDelegates = delegates.mapKeys { it.key.normalized(boundGroup) }
-		val availableEncryptionKeys = encryptionKeysOf(entityGroupId, entity, entityType, null)
-		val availableOwningEntityIds = owningEntityIdsOf(entityGroupId, entity, entityType, null)
-		val availableSecretIds = secretIdsOf(entityGroupId, entity, entityType, null)
+		val decryptedMetadata = decryptSecurityMetadataDetails(entityGroupId, entity, entityType, dataOwnersForDecryption(null).toSet())
+		val availableEncryptionKeys = decryptedMetadata.encryptionKeys.mapTo(mutableSetOf()) { it.value }
+		val availableOwningEntityIds = decryptedMetadata.owningEntityIds.mapTo(mutableSetOf()) { it.value }
+		val availableSecretIds = decryptedMetadata.secretIds.mapTo(mutableSetOf()) { it.value }
 		val extendedDelegateOptions = normalizedDelegates.mapValues { (_, simpleShareOptions) ->
 			if (availableEncryptionKeys.isEmpty() && simpleShareOptions.shareEncryptionKey == ShareMetadataBehaviour.Required) {
 				throw IllegalArgumentException("The current data owner can't access any encryption key in ${entityType.id}(\"${entity.id}\"), but sharing is required.")
@@ -634,13 +661,14 @@ class EntityEncryptionServiceImpl(
 				requestedPermissions = simpleShareOptions.requestedPermissions
 			)
 		}
-		val shareResult = bulkShareOrUpdateEncryptedEntityMetadata(
+		val shareResult = doBulkShareOrUpdateEncryptedEntityMetadata(
 			entityGroupId,
 			listOf(entity to extendedDelegateOptions),
 			entityType,
 			false,
 			getUpdatedEntity,
-			doRequestBulkShareOrUpdate
+			doRequestBulkShareOrUpdate,
+			mapOf(entity.id to decryptedMetadata)
 		)
 		if (shareResult.unmodifiedEntitiesIds.contains(entity.id)) {
 			return SimpleShareResult.Success(entity)
@@ -708,7 +736,8 @@ class EntityEncryptionServiceImpl(
 	private suspend fun prepareBulkShareRequests(
 		entityGroupId: String?,
 		entitiesUpdates: List<Pair<HasEncryptionMetadata, Map<EntityReferenceInGroup, DelegateShareOptions>>>,
-		entitiesType: EntityWithEncryptionMetadataTypeName
+		entitiesType: EntityWithEncryptionMetadataTypeName,
+		precomputedDecryptedMetadata: Map<String, PerEntityDecryptedSecurityMetadata> = emptyMap()
 	): BulkShareRequestsDetails {
 		require (entitiesUpdates.distinctBy { it.first.id }.size == entitiesUpdates.size) {
 			"Duplicate requests: the same entity id is present more than once in the input"
@@ -728,9 +757,65 @@ class EntityEncryptionServiceImpl(
 				optionsForDelegates,
 				hierarchySet
 			)
-			val otherRequests = optionsForDelegates.mapNotNull { (delegate, options) ->
+			val nonMigratedOptionsForDelegates = optionsForDelegates.filterKeys { it !in migrationRequests }
+			val reducedOptionsForDelegates = if (nonMigratedOptionsForDelegates.isNotEmpty()) {
+				val decryptedMetadata = precomputedDecryptedMetadata[entity.id]
+					?: decryptSecurityMetadataDetails(entityGroupId, entity, entitiesType, hierarchySet)
+				removeContentAlreadyKnownToDelegates(decryptedMetadata, nonMigratedOptionsForDelegates)
+			} else
+				nonMigratedOptionsForDelegates
+			// Lazy and memoized: skipped entirely if there are no non-migrated delegates left to process, and
+			// reused across every delegate below plus potentialParentDelegations afterward, instead of paying
+			// for the (potentially costly) exchange data lookup more than once.
+			var secureDelegationMembers: Map<SecureDelegationKeyString, SecureDelegationMembersDetails>? = null
+			suspend fun secureDelegationMembers() = secureDelegationMembers
+				?: baseSecurityMetadataDecryptor.getSecureDelegationMemberDetails(entityGroupId, entity, entitiesType)
+					.also { secureDelegationMembers = it }
+			// Lazy and memoized: only needed at all for a `MaxWrite` request (see impliedMinimumAccessLevel).
+			var myOwnAccessLevel: AccessLevel? = null
+			var myOwnAccessLevelComputed = false
+			suspend fun myOwnAccessLevel(): AccessLevel? {
+				if (!myOwnAccessLevelComputed) {
+					myOwnAccessLevel = baseSecurityMetadataDecryptor.getEntityAccessLevel(entityGroupId, entity, entitiesType, hierarchySet)
+					myOwnAccessLevelComputed = true
+				}
+				return myOwnAccessLevel
+			}
+			val selfReference = EntityReferenceInGroup(dataOwnerApi.getCurrentDataOwnerId(), null)
+			val otherRequests = reducedOptionsForDelegates.mapNotNull { (delegate, options) ->
+				val members = secureDelegationMembers()
+				val impliedMinimum = options.requestedPermissions.impliedMinimumAccessLevel(::myOwnAccessLevel)
+				val nothingLeftToShare = options.shareSecretIds.isEmpty() && options.shareEncryptionKeys.isEmpty() && options.shareOwningEntityIds.isEmpty()
+				// Nothing left to share content-wise means everything requested is already reachable by the
+				// delegate through some other delegation we can decrypt (see removeContentAlreadyKnownToDelegates).
+				// This alone does not mean there is nothing to do though: that other delegation may only grant a
+				// lower access level than what was requested here (e.g. already Read, but this call asks for
+				// Write) - the delegate having the content already doesn't imply they already have the requested
+				// permission level too.
+				val alreadySatisfied = nothingLeftToShare &&
+					impliedMinimum != null &&
+					bestKnownAccessLevelFor(entity, delegate, members)?.satisfies(impliedMinimum) == true
 				(
-					if (!migrationRequests.containsKey(delegate)) {
+					if (alreadySatisfied) {
+						null
+					} else {
+						// If we already have our own direct delegation to this exact delegate (in either
+						// direction - see removeContentAlreadyKnownToDelegates for why), and it doesn't already
+						// satisfy the requested permission, updating it can't get it there: existing delegations
+						// can't have their permissions changed in place (yet). Silently keeping the old, lower
+						// permission would be worse than failing loudly.
+						val myOwnDelegationToDelegate = members.values.firstOrNull {
+							(it.delegator == selfReference && it.delegate == delegate) || (it.delegate == selfReference && it.delegator == delegate)
+						}
+						if (myOwnDelegationToDelegate != null &&
+							(impliedMinimum == null || !myOwnDelegationToDelegate.accessLevel.satisfies(impliedMinimum))
+						) {
+							throw UnsupportedOperationException(
+								"Cannot change the permission of the existing delegation between $selfReference and $delegate " +
+									"from ${myOwnDelegationToDelegate.accessLevel} to satisfy the requested ${options.requestedPermissions}: " +
+									"changing the permissions of an already existing delegation is not supported yet, but will be in a future version of the sdk."
+							)
+						}
 						secureDelegationsManager.makeShareOrUpdateRequestParams(
 							entityGroupId = entityGroupId,
 							entity = entity,
@@ -741,7 +826,7 @@ class EntityEncryptionServiceImpl(
 							shareOwningEntityIds = options.shareOwningEntityIds,
 							newDelegationPermissions = options.requestedPermissions
 						)
-					} else null
+					}
 				)?.let { delegate to it }
 			}
 			val allRequests = migrationRequests.map {
@@ -750,11 +835,7 @@ class EntityEncryptionServiceImpl(
 				DelegateShareRequestDetails(it.first, optionsForDelegates[it.first], false, it.second)
 			}
 			if (allRequests.isNotEmpty()) {
-				val potentialParentDelegations = baseSecurityMetadataDecryptor.getSecureDelegationMemberDetails(
-					entityGroupId,
-					entity,
-					entitiesType
-				).mapNotNullTo(
+				val potentialParentDelegations = secureDelegationMembers().mapNotNullTo(
 					mutableSetOf()
 				) { (delegationKey, delegationInfo) ->
 					if (delegationInfo.delegate in hierarchyReferenceSet || delegationInfo.delegator in hierarchyReferenceSet)
@@ -772,6 +853,126 @@ class EntityEncryptionServiceImpl(
 			} else unmodifiedEntityIds.add(entity.id)
 		}
 		return BulkShareRequestsDetails(unmodifiedEntityIds, requestsByEntityId)
+	}
+
+	/**
+	 * All the security metadata of a single entity that we - the current actor - could decrypt, in the same shape
+	 * [removeContentAlreadyKnownToDelegates] needs it in. Computing this is the expensive part (potentially
+	 * involving exchange data lookups), so callers that already have to decrypt this to do something else (e.g.
+	 * [simpleShareOrUpdateEncryptedEntityMetadata], which needs it to resolve [SimpleDelegateShareOptions] into
+	 * concrete sets in the first place) can compute it once and pass it down instead of paying for it twice.
+	 */
+	private data class PerEntityDecryptedSecurityMetadata(
+		val secretIds: List<DecryptedMetadataDetails<String>>,
+		val encryptionKeys: List<DecryptedMetadataDetails<HexString>>,
+		val owningEntityIds: List<DecryptedMetadataDetails<String>>
+	)
+
+	private suspend fun decryptSecurityMetadataDetails(
+		entityGroupId: String?,
+		entity: HasEncryptionMetadata,
+		entityType: EntityWithEncryptionMetadataTypeName,
+		dataOwnersHierarchySubset: Set<String>
+	): PerEntityDecryptedSecurityMetadata = PerEntityDecryptedSecurityMetadata(
+		secretIds = baseSecurityMetadataDecryptor.decryptAll(
+			entityGroupId, listOf(entity), entityType, dataOwnersHierarchySubset, SecurityMetadataType.SecretId
+		).values.single(),
+		encryptionKeys = baseSecurityMetadataDecryptor.decryptAll(
+			entityGroupId, listOf(entity), entityType, dataOwnersHierarchySubset, SecurityMetadataType.EncryptionKey
+		).values.single(),
+		owningEntityIds = baseSecurityMetadataDecryptor.decryptAll(
+			entityGroupId, listOf(entity), entityType, dataOwnersHierarchySubset, SecurityMetadataType.OwningEntityId
+		).values.single()
+	)
+
+	/**
+	 * Removes from each delegate's requested content whatever is already reachable by that specific delegate
+	 * through some delegation (legacy or secure) that we - the current actor, decrypting with whatever hierarchy
+	 * [decryptedMetadata] was computed with - can already decrypt.
+	 *
+	 * This only ever removes content that the delegate can access *directly* (the delegation's own recorded
+	 * delegate matches, not some descendant reachable only by also holding the delegate's key): if A shared
+	 * something with parent P, and B (a sibling of A, also a child of P) is asked to share the same content
+	 * with P again, B can decrypt the existing A->P delegation (since B holds P's key) and see it already
+	 * covers everything - so nothing is left to share and the whole request for P can be skipped. But if A is
+	 * asked to share directly with B instead, the existing A->P delegation's recorded delegate is P, not B -
+	 * even though B could probably reach the content through P, A has no way to confirm that B actually has
+	 * the necessary permission to do so, so sharing directly with B always goes through unchanged.
+	 * Likewise, content shared by an unrelated third party (one whose delegations we can't decrypt at all,
+	 * such as X sharing further with Y, unbeknownst to A) is never considered already known, since we simply
+	 * have no visibility into it.
+	 */
+	private fun removeContentAlreadyKnownToDelegates(
+		decryptedMetadata: PerEntityDecryptedSecurityMetadata,
+		optionsForDelegates: Map<EntityReferenceInGroup, DelegateShareOptions>
+	): Map<EntityReferenceInGroup, DelegateShareOptions> =
+		optionsForDelegates.mapValues { (delegate, options) ->
+			val delegateReferenceSet = setOf(delegate)
+			options.copy(
+				shareSecretIds = options.shareSecretIds - decryptedMetadata.secretIds.valuesAvailableToDataOwners(delegateReferenceSet),
+				shareEncryptionKeys = options.shareEncryptionKeys - decryptedMetadata.encryptionKeys.valuesAvailableToDataOwners(delegateReferenceSet),
+				shareOwningEntityIds = options.shareOwningEntityIds - decryptedMetadata.owningEntityIds.valuesAvailableToDataOwners(delegateReferenceSet)
+			)
+		}
+
+	/**
+	 * The highest access level [delegate] is already known (from metadata we can decrypt/read) to have to
+	 * [entity], considering that being on *either* side of an existing delegation - delegate or delegator -
+	 * grants access to it: e.g. if A shared something with B (A->B), B already has access to it just as much
+	 * as A does, so B re-sharing that same content back with A should be recognized as already known too, not
+	 * just the more obvious A re-sharing with B. Returns null if we have no evidence of [delegate] having any
+	 * access at all.
+	 */
+	private fun bestKnownAccessLevelFor(
+		entity: HasEncryptionMetadata,
+		delegate: EntityReferenceInGroup,
+		secureDelegationMembers: Map<SecureDelegationKeyString, SecureDelegationMembersDetails>
+	): AccessLevel? {
+		// Legacy delegations only ever grant write access, and never apply across groups; the delegate id
+		// can appear as a map key (delegatedTo) and/or as the `owner` of an entry filed under another key.
+		val hasLegacyAccess = delegate.groupId == null && (
+			entity.delegations.containsKey(delegate.entityId) ||
+				entity.delegations.values.any { delegations -> delegations.any { it.owner == delegate.entityId } }
+			)
+		if (hasLegacyAccess) return AccessLevel.Write
+		return secureDelegationMembers.values
+			.filter { it.delegate == delegate || it.delegator == delegate }
+			.maxByOrNull { member -> when (member.accessLevel) { AccessLevel.Read -> 0; AccessLevel.Write -> 1 } }
+			?.accessLevel
+	}
+
+	/**
+	 * True if this access level is enough to satisfy [required], without relying on [AccessLevel] being
+	 * [Comparable]/on the order in which its entries are declared.
+	 */
+	private fun AccessLevel.satisfies(required: AccessLevel): Boolean = when (required) {
+		AccessLevel.Read -> true // any existing access level (Read or Write) satisfies a Read requirement
+		AccessLevel.Write -> this == AccessLevel.Write
+	}
+
+	/**
+	 * The lowest [AccessLevel] that would satisfy this permission request - i.e. if the delegate already
+	 * has at least this much access through some other delegation, a new one requesting this permission
+	 * wouldn't grant them anything more - or `null` if it can never be inferred as "already satisfied" by
+	 * this optimization:
+	 * - `Root` is not just "a higher Write": a delegate only truly has root if they have an actual root
+	 *   secure delegation, which we can't confirm merely from some other delegation granting Write, so a
+	 *   `Root` request always proceeds.
+	 * - `MaxRead`/`MaxWrite` cap the granted access at whatever the *current data owner* (not the delegate)
+	 *   already has: e.g. `MaxWrite` only really implies Write if the current data owner itself has Write;
+	 *   if it only has Read, that's all `MaxWrite` would actually grant too. [getMyOwnAccessLevel] is only
+	 *   invoked (and only ever needs to be) for this case.
+	 */
+	private suspend fun RequestedPermission.impliedMinimumAccessLevel(
+		getMyOwnAccessLevel: suspend () -> AccessLevel?
+	): AccessLevel? = when (this) {
+		RequestedPermission.FullRead, RequestedPermission.MaxRead -> AccessLevel.Read
+		RequestedPermission.FullWrite -> AccessLevel.Write
+		RequestedPermission.MaxWrite -> when (getMyOwnAccessLevel()) {
+			AccessLevel.Write -> AccessLevel.Write
+			AccessLevel.Read, null -> AccessLevel.Read
+		}
+		RequestedPermission.Root -> null
 	}
 
 	private suspend fun prepareMigrationRequestsIfNeeded(
@@ -890,7 +1091,10 @@ class EntityEncryptionServiceImpl(
 				missingLegacySecretIds + (userRequest?.shareSecretIds ?: emptySet()),
 				missingLegacyEncryptionKeys + (userRequest?.shareEncryptionKeys ?: emptySet()),
 				missingLegacyOwningEntityIds + (userRequest?.shareOwningEntityIds ?: emptySet()),
-				if (mustCreateRootDelegation)
+				// Independent of mustCreateRootDelegation: a migration entry for yourself is always
+				// requested as a fresh root, regardless of whether some ancestor already has write
+				// access through some other, unrelated delegation.
+				if (currMember.entityId == selfId)
 					RequestedPermission.Root
 				else
 					RequestedPermission.FullWrite // Legacy permission if present is always write

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/LegacyMetadataMigrationTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/LegacyMetadataMigrationTest.kt
@@ -2,15 +2,22 @@
 
 package com.icure.cardinal.sdk.crypto
 
+import com.icure.cardinal.sdk.CardinalSdk
 import com.icure.cardinal.sdk.api.raw.impl.RawHealthcarePartyApiImpl
 import com.icure.cardinal.sdk.api.raw.impl.RawPatientApiImpl
 import com.icure.cardinal.sdk.api.raw.impl.RawUserApiImpl
+import com.icure.cardinal.sdk.crypto.entities.PatientShareOptions
+import com.icure.cardinal.sdk.crypto.entities.SecretIdShareOptions
 import com.icure.cardinal.sdk.model.EncryptedPatient
 import com.icure.cardinal.sdk.model.HealthcareParty
 import com.icure.cardinal.sdk.model.User
+import com.icure.cardinal.sdk.model.requests.RequestedPermission
 import com.icure.cardinal.sdk.test.DataOwnerDetails
 import com.icure.cardinal.sdk.test.DefaultRawApiConfig
+import com.icure.cardinal.sdk.test.autoCancelJob
 import com.icure.cardinal.sdk.test.baseUrl
+import com.icure.cardinal.sdk.test.createHcpUser
+import com.icure.cardinal.sdk.test.initializeTestEnvironment
 import com.icure.cardinal.sdk.test.testGroupAdminAuth
 import com.icure.cardinal.sdk.test.testGroupId
 import com.icure.cardinal.sdk.utils.DEFAULT_ENABLED
@@ -21,19 +28,40 @@ import com.icure.kryptom.crypto.defaultCryptoService
 import com.icure.kryptom.utils.hexToByteArray
 import com.icure.utils.InternalIcureApi
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSingleElement
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Job
+
+private data class TestApis(
+	val a: CardinalSdk,
+	val b: CardinalSdk,
+	val p: CardinalSdk,
+	val x: CardinalSdk,
+	val x2: CardinalSdk
+)
+
+private data class TestIds(
+	val a: String,
+	val b: String,
+	val p: String,
+	val x: String,
+	val x2: String
+)
 
 private data class TestData(
-	val p: DataOwnerDetails,
-	val a: DataOwnerDetails,
-	val b: DataOwnerDetails,
-	val patientId: String,
+	val apis: TestApis,
+	val ids: TestIds,
+	val patient: EncryptedPatient,
 	val patientConfidentialSecretId: String,
 	val patientNote: String
 )
 
 // The following data was created for test purposes only and does not contain any real key / secrets.
 @InternalIcureApi
-private suspend fun createTestDataAndApis(): TestData {
+private suspend fun createTestDataAndApis(job: Job, useFakeKeyForAesExchangeKeyEntry: Boolean = false): TestData {
 	val pId = defaultCryptoService.strongRandom.randomUUID().toString()
 	val pLogin = "parent-${defaultCryptoService.strongRandom.randomUUID()}"
 	val pPassword = defaultCryptoService.strongRandom.randomUUID().toString()
@@ -69,7 +97,7 @@ private suspend fun createTestDataAndApis(): TestData {
       "firstName": "6ca3b4",
       "parentId": "$pId",
       "aesExchangeKeys": {
-        "$aPublicKey": 
+        "${if (useFakeKeyForAesExchangeKeyEntry) "x0" else aPublicKey}":
           {
             "$pId": {
               "3b42514690fbb161a5179d0203010001": 
@@ -102,13 +130,15 @@ private suspend fun createTestDataAndApis(): TestData {
 	val bPassword = defaultCryptoService.strongRandom.randomUUID().toString()
 	val bPrivateKey =
 		"308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100982330dc464b3e9c583affbfece209976bc045f07b22fb44bcb0ebc27bc9d8406b54e380d195e107c1728499a64012b3251c1c85a2516e73b89a07b1929f0c12d44828677135082e8170b9831dd4ff9e988d098731eadd1443813cb5f6af2fe4c2a2706ba6aeb5bb6bb7889be51eebd83bebbb2a0b55a6d69fdeb66894af47edd6f82a8d30629814b82f17cfd1ef75f47d192eb9577c58f14a5e0d2782b13b796b5a3be780a38b0f69f3d00179d13cc23fcec1e919ac05d88c08c693c711384ad9fc7a21ed28d0e5d3865c15db239a5d727d4c52a344975c97379cc5a195ff4f8c1aacbaa67d6d0fd358b6b5d1a4d0575bc57b2d7736108978e3371e9aa0ae8f0203010001028201002a9bac7afc9ae5399f4242cf4b36110e9de8570e1f46704dd374cf4a8425c7115f9e022b59475b23336bf1b4208a1052a8e183217010d358c88a26fe75fc6242c1be45c696bf8dff8c53f838bef9a0ef9774e486bf15b27e12dbd69775b3a1bbb5410e303019fd1eb4efcd6c2fd2a5a5c53e6388466d6210f8ec4474ecb35c76d2c4269d3a585cdce972673c56818015b9f097ff528e26272b76810cb4f8a1ee5ea04ea26f4cf3c6f78b77c5f58d80628f513a4da76cc1e35a6867af1ab76fe0354e549340221d19bfe04783e34f84eca7bd80867134710adc0665a52eb689d2cf6ecb38ca77d84f4feb8c23539e92ac870b3175c174d8f5643aabc0e7ef3cd102818100ba44b38b24e28d9fb85279c0098b4505e0852ba88b54d2cb8b0e77368c1600bb40b4c0f6dee8b97788e082af0f9045dd54f05ee583fffabc473d16272d03c1aef301541176e7a95f948f8d77b6aad087c54f2de713909efdd5d90a8bbec61067172a97480ba844c25cf64a8b1f0698e2f4dd73af798dd8ab329f7f9bf9a0f9ff02818100d11781567bde00a256ac7ef2c4bf10a5b8b2ebab77c941b7665817f17aa496f166ecd89bb4c50c53d4e836b3369edc2f0f49e64f8dbe7ddaf0fb3898075f6e82ab2c69bc925368904ba459ce08a40ce621dceefa78b64d8eb68752d1cc2a53a1db9718ab1a8703333065cf9b8407174c18f8b085e4aebf32a5bf9b259a6bab71028180492352b04f025a039df75c70e80e7442b37ef6be8e3ef72a0ee6d62e67e0f7d68eb8aa9004c4b29659fb75b4d1529fec213ee4b4101981d54dcf91943e5b9c405a9069f7158e2ef625ba1c1d266f79c3e5d88a38927915c4aba4363cdae2a06c2a2f82093af28e5516f56a1da84809de0bb1ac8bf919963ada7cc039795218f70281802b0aceaa31f78263e8b9bbac580a08f04474388564b43e5df5a87ecd4bf4e3c9afe963b1b1e5ba62eb7a1e008866ed66969c1cd81592b82fc0d9c64dad7edcadf374c2137a7fc70fa532a0f603db59786a5223b3d5f399459e977eda0750534507823426cce02c2d76720ee9b1a5100baf3c4a8255900f75ea9ee5de38ca9f510281802c19faaa1e08ac6337c48af1529f8b8685d2582586986b180377aee8cf4eaadcdbb5869c6f994275b0ae3ecc6aa0ead81296ab9a96eecb44f14fcd9e50ef34d9725e97809b3ed2ed6105102c96ea55a096f292a8d9769c05779f303dc6ad3b30c3c9bea749d58636b3977c9c593557c048b2f82e90fead32b5b510966e548e7a"
+	val bPublicKey =
+		"30820122300d06092a864886f70d01010105000382010f003082010a0282010100982330dc464b3e9c583affbfece209976bc045f07b22fb44bcb0ebc27bc9d8406b54e380d195e107c1728499a64012b3251c1c85a2516e73b89a07b1929f0c12d44828677135082e8170b9831dd4ff9e988d098731eadd1443813cb5f6af2fe4c2a2706ba6aeb5bb6bb7889be51eebd83bebbb2a0b55a6d69fdeb66894af47edd6f82a8d30629814b82f17cfd1ef75f47d192eb9577c58f14a5e0d2782b13b796b5a3be780a38b0f69f3d00179d13cc23fcec1e919ac05d88c08c693c711384ad9fc7a21ed28d0e5d3865c15db239a5d727d4c52a344975c97379cc5a195ff4f8c1aacbaa67d6d0fd358b6b5d1a4d0575bc57b2d7736108978e3371e9aa0ae8f0203010001" // pragma: allowlist secret
 	val bHcpBase: HealthcareParty = Serialization.json.decodeFromString("""{
 		"id": "$bId",
 		"lastName": "95ee22",
 		"firstName": "2af696",
 		"parentId": "$pId",
 		"aesExchangeKeys": {
-			"30820122300d06092a864886f70d01010105000382010f003082010a0282010100982330dc464b3e9c583affbfece209976bc045f07b22fb44bcb0ebc27bc9d8406b54e380d195e107c1728499a64012b3251c1c85a2516e73b89a07b1929f0c12d44828677135082e8170b9831dd4ff9e988d098731eadd1443813cb5f6af2fe4c2a2706ba6aeb5bb6bb7889be51eebd83bebbb2a0b55a6d69fdeb66894af47edd6f82a8d30629814b82f17cfd1ef75f47d192eb9577c58f14a5e0d2782b13b796b5a3be780a38b0f69f3d00179d13cc23fcec1e919ac05d88c08c693c711384ad9fc7a21ed28d0e5d3865c15db239a5d727d4c52a344975c97379cc5a195ff4f8c1aacbaa67d6d0fd358b6b5d1a4d0575bc57b2d7736108978e3371e9aa0ae8f0203010001":
+			"${if (useFakeKeyForAesExchangeKeyEntry) "x0" else bPublicKey}":
 				{
 					"$pId": {
 					"3b42514690fbb161a5179d0203010001": 
@@ -118,8 +148,7 @@ private suspend fun createTestDataAndApis(): TestData {
 				}
 			}
 		},
-		"publicKey":
-		"30820122300d06092a864886f70d01010105000382010f003082010a0282010100982330dc464b3e9c583affbfece209976bc045f07b22fb44bcb0ebc27bc9d8406b54e380d195e107c1728499a64012b3251c1c85a2516e73b89a07b1929f0c12d44828677135082e8170b9831dd4ff9e988d098731eadd1443813cb5f6af2fe4c2a2706ba6aeb5bb6bb7889be51eebd83bebbb2a0b55a6d69fdeb66894af47edd6f82a8d30629814b82f17cfd1ef75f47d192eb9577c58f14a5e0d2782b13b796b5a3be780a38b0f69f3d00179d13cc23fcec1e919ac05d88c08c693c711384ad9fc7a21ed28d0e5d3865c15db239a5d727d4c52a344975c97379cc5a195ff4f8c1aacbaa67d6d0fd358b6b5d1a4d0575bc57b2d7736108978e3371e9aa0ae8f0203010001"
+		"publicKey": "$bPublicKey"
 	}""")
 	val bUserBase: User = Serialization.json.decodeFromString("""{
 		"id": "${defaultCryptoService.strongRandom.randomUUID()}",
@@ -188,7 +217,7 @@ private suspend fun createTestDataAndApis(): TestData {
 	userApi.createUser(pUserBase)
 	userApi.createUser(aUserBase)
 	userApi.createUser(bUserBase)
-	patientApi.createPatient(patientBase)
+	val createdPatient = patientApi.createPatient(patientBase).successBody()
 	val keyP = defaultCryptoService.rsa.loadKeyPairPkcs8(RsaAlgorithm.RsaEncryptionAlgorithm.OaepWithSha1, hexToByteArray(pPrivateKey))
 	val keyA = defaultCryptoService.rsa.loadKeyPairPkcs8(RsaAlgorithm.RsaEncryptionAlgorithm.OaepWithSha1, hexToByteArray(aPrivateKey))
 	val keyB = defaultCryptoService.rsa.loadKeyPairPkcs8(RsaAlgorithm.RsaEncryptionAlgorithm.OaepWithSha1, hexToByteArray(bPrivateKey))
@@ -216,18 +245,156 @@ private suspend fun createTestDataAndApis(): TestData {
 		parent = pDataOwnerDetails,
 		groupId = testGroupId
 	)
+	// X, X2: external hcps, not related to A/B/P.
+	val xDataOwnerDetails = createHcpUser()
+	val x2DataOwnerDetails = createHcpUser()
 	return TestData(
-		p = pDataOwnerDetails,
-		a = aDataOwnerDetails,
-		b = bDataOwnerDetails,
-		patientId = patientBase.id,
+		apis = TestApis(
+			a = aDataOwnerDetails.api(job),
+			b = bDataOwnerDetails.api(job),
+			p = pDataOwnerDetails.api(job),
+			x = xDataOwnerDetails.api(job),
+			x2 = x2DataOwnerDetails.api(job)
+		),
+		ids = TestIds(
+			a = aId,
+			b = bId,
+			p = pId,
+			x = xDataOwnerDetails.dataOwnerId,
+			x2 = x2DataOwnerDetails.dataOwnerId
+		),
+		patient = createdPatient,
 		patientConfidentialSecretId = "24cd8cf5-0958-4ee9-8e90-95f3d25a47d7",
 		patientNote = "This is just a test patient"
 	)
 }
 
 class LegacyMetadataMigrationTest : StringSpec({
-	"TODO: actually implement this test".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
-		TODO("Adapt the ts test")
+	val specJob = autoCancelJob()
+
+	beforeSpec {
+		initializeTestEnvironment()
+	}
+
+	/*
+	 * Entity E with legacy metadata created by A and shared with P. There is also a confidential
+	 * secret id (known by A but not P). B (a sibling of A under the same parent P, holding P's key
+	 * locally) wants to share with X as read only.
+	 * Expected outcome:
+	 * - A root secure delegation B->B
+	 * - A delegation B->P
+	 * - Through the delegation B->P, A and P can access all the legacy metadata available to P (but
+	 *   not the confidential secret id known by A)
+	 * - A delegation from B->X
+	 * - Through B->X, X can access only the shared information and has read access only
+	 *
+	 * Now A wants to share with X2.
+	 * Expected outcome:
+	 * - A new root secure delegation A->A is available, which gives access to the confidential secret id
+	 * - A delegation A->X2 with the shared information
+	 * - Parents of the new delegation are the new A->A root delegation and the existing A->P delegation
+	 * - B and P still can't access the confidential secret id
+	 */
+	"sharing data as a child of a parent with legacy access should work".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val data = createTestDataAndApis(specJob)
+		val secretIdsKnownByA = data.apis.a.patient.getSecretIdsOf(data.patient).keys
+		val secretIdsKnownByB = data.apis.b.patient.getSecretIdsOf(data.patient).keys
+		secretIdsKnownByB shouldHaveSize 1
+		(data.patientConfidentialSecretId in secretIdsKnownByB) shouldBe false
+		secretIdsKnownByA shouldHaveSize 2
+		(data.patientConfidentialSecretId in secretIdsKnownByA) shouldBe true
+		(secretIdsKnownByB.single() in secretIdsKnownByA) shouldBe true
+
+		val sharedPatient = data.apis.b.patient.encrypted.shareWith(
+			data.ids.x,
+			data.patient,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIdsKnownByB, false)
+			)
+		)
+		val secureDelegations = sharedPatient.securityMetadata.shouldNotBeNull().secureDelegations
+		secureDelegations.values shouldHaveSize 3
+		secureDelegations.values.shouldHaveSingleElement { it.delegator == data.ids.b && it.delegate == data.ids.b }
+		val bToP = secureDelegations.entries.single { it.value.delegator == data.ids.b && it.value.delegate == data.ids.p }
+		secureDelegations.values.shouldHaveSingleElement { it.delegator == data.ids.b && it.delegate == data.ids.x }
+
+		// Stripping the legacy delegations/encryptionKeys off shows that the newly created (v8) security
+		// metadata alone is already enough for A (through B->P, reachable via P's key) to access
+		// everything that was shared with P - but not the confidential secret id, which only ever
+		// existed in the legacy metadata.
+		val strippedPatient = sharedPatient.copy(delegations = emptyMap(), encryptionKeys = emptyMap())
+		data.apis.a.patient.getEncryptionKeysOf(strippedPatient) shouldHaveSize 1
+		data.apis.a.patient.getSecretIdsOf(strippedPatient).keys shouldBe secretIdsKnownByB
+
+		data.apis.x.patient.getPatient(data.patient.id).shouldNotBeNull().note shouldBe data.patientNote
+		data.apis.x.patient.hasWriteAccess(sharedPatient) shouldBe false
+		val decryptedForX = data.apis.x.patient.getPatient(data.patient.id).shouldNotBeNull()
+		kotlin.runCatching {
+			data.apis.x.patient.modifyPatient(decryptedForX.copy(firstName = "New name"))
+		}.isSuccess shouldBe false
+		data.apis.x.patient.getSecretIdsOf(sharedPatient).keys shouldBe secretIdsKnownByB
+
+		val sharedPatient2 = data.apis.a.patient.encrypted.shareWith(
+			data.ids.x2,
+			sharedPatient,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIdsKnownByB, false)
+			)
+		)
+		val secureDelegations2 = sharedPatient2.securityMetadata.shouldNotBeNull().secureDelegations
+		secureDelegations2.values shouldHaveSize 5
+		val aToA = secureDelegations2.entries.single { it.value.delegator == data.ids.a && it.value.delegate == data.ids.a }
+		// A's own migration entry is a fresh, independent root: it has no parents of its own.
+		aToA.value.parentDelegations.shouldBeEmpty()
+		val aToX2 = secureDelegations2.values.single { it.delegator == data.ids.a && it.delegate == data.ids.x2 }
+		// Parented on both the new A->A root and the pre-existing B->P delegation, since that's the
+		// (only) existing delegation reachable through A's hierarchy (via P) prior to this share.
+		aToX2.parentDelegations shouldBe setOf(aToA.key, bToP.key)
+
+		data.apis.b.patient.getSecretIdsOf(sharedPatient2).keys shouldBe secretIdsKnownByB
+	}
+
+	/*
+	 * Entity E with legacy metadata created by A and shared with P. There is also a confidential
+	 * secret id (known by A but not P). A wants to share with X as read only.
+	 * Expected outcome:
+	 * - A root secure delegation for A
+	 * - A->A includes the confidential secret id known by A
+	 * - A delegation from A to P
+	 * - Through the delegation A->P, A and P can access all the legacy metadata available to P (but
+	 *   not the confidential secret id)
+	 */
+	"sharing data created with legacy api by the same user".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val data = createTestDataAndApis(specJob)
+		val secretIdsKnownByA = data.apis.a.patient.getSecretIdsOf(data.patient).keys
+		val secretIdsKnownByB = data.apis.b.patient.getSecretIdsOf(data.patient).keys
+
+		val sharedPatient = data.apis.a.patient.encrypted.shareWith(
+			data.ids.x,
+			data.patient,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIdsKnownByB, false)
+			)
+		)
+		val secureDelegations = sharedPatient.securityMetadata.shouldNotBeNull().secureDelegations.values
+		secureDelegations shouldHaveSize 3
+		secureDelegations.shouldHaveSingleElement { it.delegator == data.ids.a && it.delegate == data.ids.a }
+		secureDelegations.shouldHaveSingleElement { it.delegator == data.ids.a && it.delegate == data.ids.p }
+		secureDelegations.shouldHaveSingleElement { it.delegator == data.ids.a && it.delegate == data.ids.x }
+
+		val strippedPatient = sharedPatient.copy(delegations = emptyMap(), encryptionKeys = emptyMap())
+		data.apis.a.patient.getSecretIdsOf(strippedPatient).keys shouldBe secretIdsKnownByA
+		data.apis.b.patient.getSecretIdsOf(sharedPatient).keys shouldBe secretIdsKnownByB
+		data.apis.b.patient.getSecretIdsOf(strippedPatient).keys shouldBe secretIdsKnownByB
+		data.apis.x.patient.getSecretIdsOf(sharedPatient).keys shouldBe secretIdsKnownByB
+	}
+
+	"should be able to use aesExchangeKeysEntries with fake public key".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val data = createTestDataAndApis(specJob, useFakeKeyForAesExchangeKeyEntry = true)
+		data.apis.a.patient.getPatient(data.patient.id).shouldNotBeNull().note shouldBe data.patientNote
+		data.apis.b.patient.getPatient(data.patient.id).shouldNotBeNull().note shouldBe data.patientNote
 	}
 })

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/PatientMergingTests.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/PatientMergingTests.kt
@@ -1,0 +1,445 @@
+@file:OptIn(InternalIcureApi::class)
+
+package com.icure.cardinal.sdk.crypto
+
+import com.icure.cardinal.sdk.CardinalSdk
+import com.icure.cardinal.sdk.api.raw.impl.RawHealthcarePartyApiImpl
+import com.icure.cardinal.sdk.api.raw.impl.RawPatientApiImpl
+import com.icure.cardinal.sdk.crypto.entities.PatientShareOptions
+import com.icure.cardinal.sdk.crypto.entities.SecretIdShareOptions
+import com.icure.cardinal.sdk.model.DecryptedPatient
+import com.icure.cardinal.sdk.model.EncryptedPatient
+import com.icure.cardinal.sdk.model.embed.AccessLevel
+import com.icure.cardinal.sdk.model.embed.Delegation
+import com.icure.cardinal.sdk.model.specializations.AesExchangeKeyEncryptionKeypairIdentifier
+import com.icure.cardinal.sdk.model.specializations.AesExchangeKeyEntryKeyString
+import com.icure.cardinal.sdk.model.specializations.HexString
+import com.icure.cardinal.sdk.model.specializations.SpkiHexString
+import com.icure.cardinal.sdk.test.DataOwnerDetails
+import com.icure.cardinal.sdk.test.DefaultRawApiConfig
+import com.icure.cardinal.sdk.test.autoCancelJob
+import com.icure.cardinal.sdk.test.baseUrl
+import com.icure.cardinal.sdk.test.createHcpUser
+import com.icure.cardinal.sdk.test.initializeTestEnvironment
+import com.icure.cardinal.sdk.test.shouldBeNextRevOf
+import com.icure.cardinal.sdk.test.testGroupAdminAuth
+import com.icure.cardinal.sdk.test.uuid
+import com.icure.cardinal.sdk.utils.DEFAULT_ENABLED
+import com.icure.cardinal.sdk.utils.EntityEncryptionException
+import com.icure.cardinal.sdk.utils.LOCAL_ENV_ONLY
+import com.icure.kryptom.crypto.AesAlgorithm
+import com.icure.kryptom.crypto.AesKey
+import com.icure.kryptom.crypto.PublicRsaKey
+import com.icure.kryptom.crypto.RsaAlgorithm
+import com.icure.kryptom.crypto.RsaKeypair
+import com.icure.kryptom.crypto.defaultCryptoService
+import com.icure.kryptom.utils.toHexString
+import com.icure.utils.InternalIcureApi
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Legacy (v7-native) AES exchange keys for a single data owner, shared with a single parent. Unlike
+ * the typescript sdk, which can generate genuine v7 fixtures by literally running the old sdk version,
+ * cardinal-sdk was built on top of the v8 (secureDelegations) crypto scheme and never had a v7-shaped
+ * writer: it can only decode this legacy shape (see BaseExchangeKeysManagerImpl and
+ * BaseSecurityMetadataDecryptorImpl.tryDecryptLegacyDelegation), never produce it. This builds fixtures
+ * that satisfy that decoder by calling the same underlying primitives (rsa/aes encrypt) in reverse,
+ * so that fresh keys/ids can be used on every run instead of baking a single set of hex constants in.
+ */
+private class LegacyExchangeKeys(
+	val hcpAesExchangeKeys: Map<AesExchangeKeyEntryKeyString, Map<String, Map<AesExchangeKeyEncryptionKeypairIdentifier, HexString>>>,
+	val selfExchangeKey: AesKey<AesAlgorithm.CbcWithPkcs7Padding>,
+	val toParentExchangeKey: AesKey<AesAlgorithm.CbcWithPkcs7Padding>
+)
+
+private suspend fun rsaEncryptExchangeKey(
+	exchangeKey: AesKey<AesAlgorithm.CbcWithPkcs7Padding>,
+	publicKey: PublicRsaKey<RsaAlgorithm.RsaEncryptionAlgorithm>
+): HexString = HexString(
+	defaultCryptoService.rsa.encrypt(defaultCryptoService.aes.exportKey(exchangeKey), publicKey).toHexString()
+)
+
+// The legacy Delegation.key format is aes(iv || "<entityId>:<value>", exchangeKey), verified against
+// tryDecryptLegacyDelegation's decode side.
+private suspend fun legacyDelegationValue(
+	entityId: String,
+	value: String,
+	exchangeKey: AesKey<AesAlgorithm.CbcWithPkcs7Padding>
+): HexString = HexString(
+	defaultCryptoService.aes.encrypt("$entityId:$value".encodeToByteArray(), exchangeKey).toHexString()
+)
+
+private suspend fun createLegacyExchangeKeys(
+	ownerKeypair: RsaKeypair<RsaAlgorithm.RsaEncryptionAlgorithm>,
+	ownerId: String,
+	parentKeypair: RsaKeypair<RsaAlgorithm.RsaEncryptionAlgorithm>,
+	parentId: String
+): LegacyExchangeKeys {
+	val crypto = defaultCryptoService
+	val ownerSpkiHex = crypto.rsa.exportPublicKeySpki(ownerKeypair.public).toHexString()
+	val ownerFingerprint = AesExchangeKeyEncryptionKeypairIdentifier(SpkiHexString(ownerSpkiHex).fingerprintV1().s)
+	val parentSpkiHex = crypto.rsa.exportPublicKeySpki(parentKeypair.public).toHexString()
+	val parentFingerprint = AesExchangeKeyEncryptionKeypairIdentifier(SpkiHexString(parentSpkiHex).fingerprintV1().s)
+	val selfExchangeKey = crypto.aes.generateKey(AesAlgorithm.CbcWithPkcs7Padding)
+	val toParentExchangeKey = crypto.aes.generateKey(AesAlgorithm.CbcWithPkcs7Padding)
+	return LegacyExchangeKeys(
+		hcpAesExchangeKeys = mapOf(
+			AesExchangeKeyEntryKeyString(ownerSpkiHex) to mapOf(
+				ownerId to mapOf(ownerFingerprint to rsaEncryptExchangeKey(selfExchangeKey, ownerKeypair.public)),
+				parentId to mapOf(
+					ownerFingerprint to rsaEncryptExchangeKey(toParentExchangeKey, ownerKeypair.public),
+					parentFingerprint to rsaEncryptExchangeKey(toParentExchangeKey, parentKeypair.public)
+				)
+			)
+		),
+		selfExchangeKey = selfExchangeKey,
+		toParentExchangeKey = toParentExchangeKey
+	)
+}
+
+/**
+ * Creates a healthcare party with legacy (OaepWithSha1, single `publicKey`) encryption metadata, as a
+ * child of [parent], with the aesExchangeKeys it needs to create legacy-shaped delegations for itself
+ * and for [parent] - the "v7 SDK" precondition of the CSM-814 suite.
+ */
+private suspend fun createLegacyHcpUser(parent: DataOwnerDetails): Pair<DataOwnerDetails, LegacyExchangeKeys> {
+	val owner = createHcpUser(parent, useLegacyKey = true)
+	val exchangeKeys = createLegacyExchangeKeys(
+		ownerKeypair = owner.keypair!!,
+		ownerId = owner.dataOwnerId,
+		parentKeypair = parent.keypair!!,
+		parentId = parent.dataOwnerId
+	)
+	val hcpRawApi = RawHealthcarePartyApiImpl(baseUrl, testGroupAdminAuth(), DefaultRawApiConfig)
+	val current = hcpRawApi.getHealthcareParty(owner.dataOwnerId).successBody()
+	hcpRawApi.modifyHealthcareParty(current.copy(aesExchangeKeys = exchangeKeys.hcpAesExchangeKeys)).successBody()
+	return owner to exchangeKeys
+}
+
+/** Inserts a legacy (v7-native, already shared with [parentId]) patient directly through the raw api,
+ * bypassing withEncryptionMetadata entirely - cardinal-sdk itself can never produce this shape. */
+private suspend fun createLegacyPatientSharedWithParent(
+	owner: DataOwnerDetails,
+	exchangeKeys: LegacyExchangeKeys,
+	parentId: String,
+	firstName: String
+): EncryptedPatient {
+	val patientId = uuid()
+	val secretId = uuid()
+	val encryptionKeyHex = uuid().replace("-", "")
+	val patient = EncryptedPatient(
+		id = patientId,
+		firstName = firstName,
+		lastName = "Doe",
+		delegations = mapOf(
+			owner.dataOwnerId to setOf(
+				Delegation(owner.dataOwnerId, owner.dataOwnerId, legacyDelegationValue(patientId, secretId, exchangeKeys.selfExchangeKey))
+			),
+			parentId to setOf(
+				Delegation(owner.dataOwnerId, parentId, legacyDelegationValue(patientId, secretId, exchangeKeys.toParentExchangeKey))
+			)
+		),
+		encryptionKeys = mapOf(
+			owner.dataOwnerId to setOf(
+				Delegation(owner.dataOwnerId, owner.dataOwnerId, legacyDelegationValue(patientId, encryptionKeyHex, exchangeKeys.selfExchangeKey))
+			),
+			parentId to setOf(
+				Delegation(owner.dataOwnerId, parentId, legacyDelegationValue(patientId, encryptionKeyHex, exchangeKeys.toParentExchangeKey))
+			)
+		)
+	)
+	return RawPatientApiImpl(baseUrl, testGroupAdminAuth(), null, DefaultRawApiConfig).createPatient(patient).successBody()
+}
+
+/** Creates a patient the normal (v8) way and immediately shares it with [parentId]. Returned in its
+ * encrypted flavour so it can be handled uniformly with legacy-created patients in the same test. */
+private suspend fun createV8PatientSharedWithParent(ownerApi: CardinalSdk, parentId: String, firstName: String): EncryptedPatient {
+	val created = ownerApi.patient.createPatient(
+		ownerApi.patient.withEncryptionMetadata(
+			DecryptedPatient(id = uuid(), firstName = firstName, lastName = "Doe"),
+			delegates = mapOf(parentId to AccessLevel.Write)
+		)
+	)
+	return ownerApi.patient.encrypted.getPatient(created.id).shouldNotBeNull()
+}
+
+class PatientMergingTests : StringSpec({
+	val specJob = autoCancelJob()
+
+	beforeSpec {
+		initializeTestEnvironment()
+	}
+
+	"A user should be able to share a just created patient secret id".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val grand = createHcpUser()
+		val parent = createHcpUser(grand)
+		val child = createHcpUser(parent)
+		// Direct child of grand (not of parent): a sibling of parent, not of child, that only holds
+		// grand's key locally - it can only see what child auto-shared up to grand.
+		val child2 = createHcpUser(grand)
+		val childApi = child.api(specJob)
+		val child2Api = child2.api(specJob)
+
+		val pat = childApi.patient.createPatient(
+			childApi.patient.withEncryptionMetadata(
+				DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"),
+				user = childApi.user.getCurrentUser()
+			)
+		)
+		val initialSecretIds = childApi.patient.getSecretIdsOf(pat).keys
+		initialSecretIds shouldBe setOf(initialSecretIds.single())
+		child2Api.patient.getSecretIdsOf(pat).keys shouldBe initialSecretIds
+
+		val newSecretId = uuid()
+		val allSecretIds = initialSecretIds + newSecretId
+		val shared = childApi.patient.shareWith(
+			grand.dataOwnerId,
+			pat,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(allSecretIds, true))
+		)
+
+		childApi.patient.getSecretIdsOf(shared).keys shouldBe allSecretIds
+		child2Api.patient.getSecretIdsOf(shared).keys shouldBe allSecretIds
+	}
+
+	"A user should be able to share the secret id of a just created patient and add a new secret id to a legacy patient created by an old sdk version, in the same operation".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		// P, the shared parent of A and B, and the delegate the legacy patient is already shared with.
+		val p = createHcpUser()
+		val (a, aExchangeKeys) = createLegacyHcpUser(p)
+		val legacyPatient = createLegacyPatientSharedWithParent(a, aExchangeKeys, p.dataOwnerId, "John")
+
+		// B, a sibling of A under the same parent P. B has no direct access to the patient, but holds
+		// P's key locally (a shared workstation), so it can decrypt anything shared with P, both before
+		// and after the new secret id is added.
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		val initialSecretIds = aApi.patient.getSecretIdsOf(legacyPatient).keys
+		initialSecretIds shouldBe setOf(initialSecretIds.single())
+		bApi.patient.getSecretIdsOf(legacyPatient).keys shouldBe initialSecretIds
+
+		val newSecretId = uuid()
+		val allSecretIds = initialSecretIds + newSecretId
+		val shared = aApi.patient.encrypted.shareWith(
+			p.dataOwnerId,
+			legacyPatient,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(allSecretIds, true))
+		)
+
+		aApi.patient.getSecretIdsOf(shared).keys shouldBe allSecretIds
+		p.api(specJob).patient.getSecretIdsOf(shared).keys shouldBe allSecretIds
+		bApi.patient.getSecretIdsOf(shared).keys shouldBe allSecretIds
+	}
+
+	val versions = listOf("v8", "v7")
+	for (fromVersion in versions) {
+		for (intoVersion in versions) {
+			for (mergedBy in listOf("A", "B")) {
+				"mergePatients merges a $fromVersion patient owned by A into a $intoVersion patient owned by B, both shared with the same parent P, merge performed by $mergedBy".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+					// Shared parent P and two sibling hcps A and B (both legacy-keyed, both holding P's
+					// key locally too, standing in for a shared workstation), regardless of which of
+					// A/B performs the merge.
+					val p = createHcpUser()
+					val (a, aExchangeKeys) = createLegacyHcpUser(p)
+					val (b, bExchangeKeys) = createLegacyHcpUser(p)
+					val aApi = a.api(specJob)
+					val bApi = b.api(specJob)
+
+					val pA = if (fromVersion == "v8")
+						createV8PatientSharedWithParent(aApi, p.dataOwnerId, "John")
+					else
+						createLegacyPatientSharedWithParent(a, aExchangeKeys, p.dataOwnerId, "John")
+					val pB = if (intoVersion == "v8")
+						createV8PatientSharedWithParent(bApi, p.dataOwnerId, "Jack")
+					else
+						createLegacyPatientSharedWithParent(b, bExchangeKeys, p.dataOwnerId, "Jack")
+
+					val aSecretId = aApi.patient.getSecretIdsOf(pA).keys.single()
+					val bSecretId = bApi.patient.getSecretIdsOf(pB).keys.single()
+					val allSecretIds = setOf(aSecretId, bSecretId)
+
+					val merger = if (mergedBy == "A") aApi else bApi
+					val otherId = if (mergedBy == "A") b.dataOwnerId else a.dataOwnerId
+					val mergedInto = merger.patient.encrypted.mergePatients(pA, pB)
+
+					// Documented merge metadata: `from` is soft-deleted and points to `into`; `into`
+					// records the merge.
+					val fromAfterMerge = aApi.patient.encrypted.getPatient(pA.id).shouldNotBeNull()
+					fromAfterMerge.deletionDate.shouldNotBeNull()
+					fromAfterMerge.mergeToPatientId shouldBe pB.id
+					mergedInto.mergedIds shouldContain pA.id
+
+					// Per mergePatients' own documentation, the merge alone does not share the merged
+					// content with users that only had access to one of the two original entities: the
+					// merger has to explicitly share with the other sibling afterwards for both to end
+					// up with full access to both secret ids.
+					val reshared = merger.patient.encrypted.shareWithMany(
+						mergedInto,
+						mapOf(otherId to PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(allSecretIds, true)))
+					)
+
+					aApi.patient.getSecretIdsOf(reshared).keys shouldBe allSecretIds
+					bApi.patient.getSecretIdsOf(reshared).keys shouldBe allSecretIds
+				}
+			}
+		}
+	}
+
+	/*
+	 * mergePatients only merges the two entities' existing security metadata (secret id/encryption key
+	 * delegations) server-side, without decrypting anything: whatever a data owner could access on one
+	 * of the two original patients, it can still access on the merged patient, and nothing more. This
+	 * holds regardless of which of A, B, or a completely unrelated third hcp performs the merge, since
+	 * the merger's own identity only matters for re-encrypting the `into` patient's content for itself,
+	 * not for the secret id metadata merge itself.
+	 *
+	 * A, B and C are all hierarchical children of the same parent P: mergePatients (like most write
+	 * operations) is only authorized between data owners with some existing relationship, so C stands
+	 * in for "anyone else in the same care organisation", not a random unrelated hcp - an entirely
+	 * unrelated hcp would get a 403. Being hierarchical children, A/B/C each also hold P's key locally
+	 * (the same "shared workstation" setup used elsewhere in this suite), so on top of their own secret
+	 * id and whatever was explicitly shared with them, they can also independently decrypt anything
+	 * shared with P - merging does not change or extend this in any way.
+	 */
+	for (merger in listOf("A", "B", "C")) {
+		"mergePatients preserves secret id visibility independently of the merger, regardless of who performs it (merged by $merger)".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+			val p = createHcpUser()
+			val pApi = p.api(specJob)
+			val a = createHcpUser(p)
+			val b = createHcpUser(p)
+			val c = createHcpUser(p)
+			val aApi = a.api(specJob)
+			val bApi = b.api(specJob)
+			val cApi = c.api(specJob)
+
+			// PatientA: s1 is A's own secret id, s2 gets additionally shared with the parent P.
+			val createdPA = aApi.patient.createPatient(
+				aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+			)
+			val s1 = aApi.patient.getSecretIdsOf(createdPA).keys.single()
+			val s2 = uuid()
+			val pA = aApi.patient.shareWith(
+				p.dataOwnerId,
+				createdPA,
+				PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(setOf(s2), true))
+			)
+
+			// PatientB: s3 is B's own secret id, s4 gets additionally shared with the same parent P.
+			val createdPB = bApi.patient.createPatient(
+				bApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "Jack", lastName = "Doe"))
+			)
+			val s3 = bApi.patient.getSecretIdsOf(createdPB).keys.single()
+			val s4 = uuid()
+			val pB = bApi.patient.shareWith(
+				p.dataOwnerId,
+				createdPB,
+				PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(setOf(s4), true))
+			)
+
+			val mergerApi = when (merger) {
+				"A" -> aApi
+				"B" -> bApi
+				else -> cApi
+			}
+			val merged = mergerApi.patient.encrypted.mergePatients(
+				aApi.patient.encrypted.getPatient(pA.id).shouldNotBeNull(),
+				bApi.patient.encrypted.getPatient(pB.id).shouldNotBeNull()
+			)
+
+			// Each of A and B keeps its own secret id, plus whichever of s2/s4 was shared with P (which
+			// both can reach independently of the merge, through P's key); P keeps exactly what was
+			// shared with it, nothing more (in particular, no access to s1 or s3).
+			aApi.patient.getSecretIdsOf(merged).keys shouldBe setOf(s1, s2, s4)
+			bApi.patient.getSecretIdsOf(merged).keys shouldBe setOf(s2, s3, s4)
+			pApi.patient.getSecretIdsOf(merged).keys shouldBe setOf(s2, s4)
+		}
+	}
+
+	/*
+	 * mergePatients forcefully disables merging the `from` patient's encryption key into the `into`
+	 * patient (the `into` patient keeps only its own, pre-existing encryption key). One consequence is
+	 * a corner case: if the `into` patient's encryption key was never shared with a party that did have
+	 * the `from` patient's encryption key, that party loses the ability to decrypt the merged patient's
+	 * content (though not its secret ids, which are unaffected and still merge normally) - a followup
+	 * shareWith/shareWithMany restores it. Sharing only the encryption key (shareSecretIds = emptySet())
+	 * again with someone who already has it is a harmless no-op, even when the caller isn't the entity's
+	 * original creator.
+	 */
+	"mergePatients does not merge encryption keys, and a follow-up shareWith restores lost access for whoever needs it".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val pApi = p.api(specJob)
+		// A and B are children of the same parent P, so that A is authorized to merge B's patient into
+		// its own.
+		val a = createHcpUser(p)
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		// PatientA created by A, but for some reason not shared with the parent at all.
+		val pA = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe", note = "note from A"))
+		)
+
+		// PatientB created by B and properly shared with the parent (secret id + encryption key).
+		val createdPB = bApi.patient.createPatient(
+			bApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "Jack", lastName = "Doe", note = "note from B"))
+		)
+		val bSecretId = bApi.patient.getSecretIdsOf(createdPB).keys.single()
+		val pB = bApi.patient.shareWith(
+			p.dataOwnerId,
+			createdPB,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(setOf(bSecretId), true))
+		)
+		pApi.patient.getSecretIdsOf(pB).keys shouldBe setOf(bSecretId)
+
+		// A merges PatientB into PatientA: PatientB's secret id still gets merged in (unaffected), but
+		// PatientA's own encryption key is the only one that survives on the merged patient - so even
+		// though the parent could decrypt PatientB's content a moment ago, it now can't decrypt the
+		// merged patient's content at all, despite still being able to find the merged-in secret id.
+		val merged = aApi.patient.mergePatients(pB, pA)
+
+		pApi.patient.getSecretIdsOf(merged).keys shouldBe setOf(bSecretId)
+		shouldThrow<EntityEncryptionException> {
+			pApi.patient.decrypt(listOf(pApi.patient.encrypted.getPatient(merged.id).shouldNotBeNull()))
+		}
+
+		// A shares just the encryption key with the parent to fix this: shareSecretIds is left empty
+		// (no new secret id to share). This is a real change (the parent never had access to this
+		// specific entity before), so the rev changes.
+		val resharedByA = aApi.patient.shareWith(
+			p.dataOwnerId,
+			merged,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(emptySet(), true))
+		)
+		resharedByA.rev shouldBeNextRevOf merged.rev
+
+		// Redundant reshare of an already-shared encryption key, this time performed by another child
+		// itself rather than the entity's original creator: a harmless no-op - nothing to write, so the
+		// rev stays the same.
+		val reshareAgain = bApi.patient.shareWith(
+			p.dataOwnerId,
+			resharedByA,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(emptySet(), true))
+		)
+		reshareAgain.rev shouldBe resharedByA.rev
+
+		// shareWithMany to a mix of delegates that already have the key (the parent) and delegates that
+		// don't yet (a fresh, unrelated hcp) also works cleanly - D's part is a real change regardless,
+		// so the rev changes overall, and D can now decrypt the content.
+		val d = createHcpUser()
+		val sharedWithBoth = aApi.patient.shareWithMany(
+			reshareAgain,
+			mapOf(
+				p.dataOwnerId to PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(emptySet(), true)),
+				d.dataOwnerId to PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(emptySet(), true))
+			)
+		)
+		sharedWithBoth.rev shouldBeNextRevOf reshareAgain.rev
+		d.api(specJob).patient.getPatient(sharedWithBoth.id).shouldNotBeNull().note shouldBe "note from A"
+	}
+})

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/SharingOptimizationTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/SharingOptimizationTest.kt
@@ -1,0 +1,430 @@
+package com.icure.cardinal.sdk.crypto
+
+import com.icure.cardinal.sdk.crypto.entities.PatientShareOptions
+import com.icure.cardinal.sdk.crypto.entities.SecretIdShareOptions
+import com.icure.cardinal.sdk.crypto.entities.ShareMetadataBehaviour
+import com.icure.cardinal.sdk.model.DecryptedPatient
+import com.icure.cardinal.sdk.model.requests.RequestedPermission
+import com.icure.cardinal.sdk.test.autoCancelJob
+import com.icure.cardinal.sdk.test.createHcpUser
+import com.icure.cardinal.sdk.test.initializeTestEnvironment
+import com.icure.cardinal.sdk.test.uuid
+import com.icure.cardinal.sdk.utils.DEFAULT_ENABLED
+import com.icure.cardinal.sdk.utils.LOCAL_ENV_ONLY
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Validates the "nothing new to share, don't write anything" optimization in
+ * `EntityEncryptionServiceImpl.prepareBulkShareRequests` (removeContentAlreadyKnownToDelegates /
+ * bestKnownAccessLevelFor): sharing content with a delegate should be a genuine no-op (rev unchanged)
+ * whenever the delegate already has both the content and at least the requested access level through
+ * some other delegation the current actor can decrypt - and should NOT be a no-op if either of those two
+ * conditions isn't actually known to be met.
+ */
+class SharingOptimizationTest : StringSpec({
+	val specJob = autoCancelJob()
+
+	beforeSpec {
+		initializeTestEnvironment()
+	}
+
+	"sharing again with a parent that already has access through a sibling's delegation is a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// B (A's sibling, holding P's key) tries to share the exact same thing with P again: B can
+		// decrypt the existing A->P delegation (through P's key) and sees it already covers everything
+		// requested, so nothing new is written.
+		val reshared = bApi.patient.shareWith(
+			p.dataOwnerId,
+			sharedWithP,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		reshared.rev shouldBe sharedWithP.rev
+	}
+
+	"sharing with a parent again through an unrelated third party who cannot see the existing delegation is not a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val x = createHcpUser()
+		val aApi = a.api(specJob)
+		val xApi = x.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		val sharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithP,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// X has no way of knowing P already has access: it holds neither A's nor P's key, so it can't
+		// decrypt the A->P delegation to check its content - its own attempt to share the same content
+		// with P goes through unchanged.
+		val xKnownSecretIds = xApi.patient.getSecretIdsOf(sharedWithX).keys
+		val resharedByX = xApi.patient.shareWith(
+			p.dataOwnerId,
+			sharedWithX,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(xKnownSecretIds, false))
+		)
+		resharedByX.rev shouldNotBe sharedWithX.rev
+	}
+
+	"sharing directly with a sibling is not a no-op even if the parent already has access to the same content".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// Even though B (A's sibling) could probably reach the same content through P, A has no way to
+		// confirm that B actually has the necessary permission to do so - sharing directly with B always
+		// goes through unchanged.
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			sharedWithP,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		sharedWithB.rev shouldNotBe sharedWithP.rev
+	}
+
+	"re-sharing the exact same content with the same delegate again is a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val x = createHcpUser()
+		val aApi = a.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// A created the A->X delegation itself, so it can always decrypt it and see it already covers
+		// everything requested.
+		val resharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithX,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		resharedWithX.rev shouldBe sharedWithX.rev
+	}
+
+	"sharing with a delegate that received access indirectly through someone else is not a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val x = createHcpUser()
+		val y = createHcpUser()
+		val aApi = a.api(specJob)
+		val xApi = x.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		val sharedWithY = xApi.patient.shareWith(
+			y.dataOwnerId,
+			sharedWithX,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// A has no visibility into the X->Y delegation (it holds neither X's nor Y's key), so it has no
+		// way of knowing Y already has this content through X - sharing with Y directly goes through
+		// unchanged.
+		val resharedByA = aApi.patient.shareWith(
+			y.dataOwnerId,
+			sharedWithY,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+		resharedByA.rev shouldNotBe sharedWithY.rev
+	}
+
+	"sharing again with a higher requested permission creates a fresh delegation with the upgraded access level even if all the content was already known".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		// A and B are siblings under the same parent P. A shares read-only access to the patient with P,
+		// and separately gives B its own (write-level) direct access. B - a different delegator than A,
+		// so its own share creates a brand new (B->P) delegation rather than colliding with the existing
+		// A->P one - can decrypt the existing A->P delegation through P's key, so it knows P already has
+		// everything content-wise; it then shares the same content with P again, but requesting write
+		// access this time. Since B itself has write access, it is allowed to grant it to P too, and since
+		// there is nothing new to add content-wise, only the escalated permission is what actually changes.
+		//
+		// Note: this deliberately uses a different delegator (B) for the upgrade. A trying to upgrade its
+		// own existing A->P delegation this same way hits a separate, deeper limitation: permissions can't
+		// be changed on an already-existing delegation in place at all (yet), so a same-delegator re-share
+		// requesting a higher permission is currently still a no-op regardless of this optimization.
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+		val pApi = p.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		pApi.patient.hasWriteAccess(sharedWithP) shouldBe false
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			sharedWithP,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// Same content, but this time requesting write access: P already has everything content-wise
+		// (reachable by B through the existing A->P delegation), but not yet the requested permission
+		// level, so a new (B->P) delegation carrying the higher access level - with nothing re-shared,
+		// since the content itself was already known - has to be created.
+		val upgraded = bApi.patient.shareWith(
+			p.dataOwnerId,
+			sharedWithB,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullWrite,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		upgraded.rev shouldNotBe sharedWithB.rev
+		pApi.patient.hasWriteAccess(upgraded) shouldBe true
+	}
+
+	"sharing back with the original sharer through the same delegation is a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val b = createHcpUser()
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false))
+		)
+
+		// B, the delegate of the A->B delegation, already gives A (the delegator) access to the same
+		// content just as much as it gives it to B itself - so B re-sharing that same content back with
+		// A is recognized as already known too, not just the more obvious "A re-sharing with B".
+		val bKnownSecretIds = bApi.patient.getSecretIdsOf(sharedWithB).keys
+		val resharedWithA = bApi.patient.shareWith(
+			a.dataOwnerId,
+			sharedWithB,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(bKnownSecretIds, false))
+		)
+		resharedWithA.rev shouldBe sharedWithB.rev
+	}
+
+	"re-requesting a higher permission from the same delegator on their own existing delegation fails loudly instead of silently keeping the old permission".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val x = createHcpUser()
+		val aApi = a.api(specJob)
+		val xApi = x.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+		val sharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			created,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		xApi.patient.hasWriteAccess(sharedWithX) shouldBe false
+
+		// A itself (the same delegator as before) tries to upgrade its own A->X delegation from read to
+		// write: unlike the previous test (where a *different* delegator performed the upgrade, creating
+		// a brand new delegation), this collides with the existing A->X delegation - permissions can't be
+		// changed on an already-existing delegation in place (yet), so this must fail loudly rather than
+		// silently leave X with only read access.
+		shouldThrow<UnsupportedOperationException> {
+			aApi.patient.shareWith(
+				x.dataOwnerId,
+				sharedWithX,
+				PatientShareOptions(
+					requestedPermissions = RequestedPermission.FullWrite,
+					shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+				)
+			)
+		}
+	}
+
+	"sharing partially-already-known content is not a no-op and updates the existing delegation instead of duplicating it".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val aApi = a.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+
+		// Share only the secret id with P, deliberately not the encryption key.
+		val sharedSecretIdOnly = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(
+				shareEncryptionKey = ShareMetadataBehaviour.Never,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		val delegationCountBefore = sharedSecretIdOnly.securityMetadata.shouldNotBeNull().secureDelegations.size
+		val aToPBefore = sharedSecretIdOnly.securityMetadata.shouldNotBeNull().secureDelegations.values.single { it.delegate == p.dataOwnerId }
+		aToPBefore.secretIds shouldHaveSize 1
+		aToPBefore.encryptionKeys.shouldBeEmpty()
+
+		// Sharing the same secret id again, but this time also the encryption key: the secret id is
+		// already known to P so it must not be duplicated, but the encryption key is genuinely new - this
+		// must not be a no-op, and must update the *same* existing delegation rather than create a new one.
+		val sharedBoth = aApi.patient.shareWith(
+			p.dataOwnerId,
+			sharedSecretIdOnly,
+			PatientShareOptions(
+				shareEncryptionKey = ShareMetadataBehaviour.Required,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		sharedBoth.rev shouldNotBe sharedSecretIdOnly.rev
+		sharedBoth.securityMetadata.shouldNotBeNull().secureDelegations.size shouldBe delegationCountBefore
+		val aToPAfter = sharedBoth.securityMetadata.shouldNotBeNull().secureDelegations.values.single { it.delegate == p.dataOwnerId }
+		aToPAfter.secretIds shouldHaveSize 1
+		aToPAfter.encryptionKeys shouldHaveSize 1
+	}
+
+	"sharing the union of an already-known secret id and a newly added confidential one results in exactly both, without duplicating the already-known one".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val aApi = a.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val originalSecretId = aApi.patient.getSecretIdsOf(created).keys.single()
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(setOf(originalSecretId), false))
+		)
+		sharedWithP.securityMetadata.shouldNotBeNull().secureDelegations.values.single { it.delegate == p.dataOwnerId }.secretIds shouldHaveSize 1
+
+		// A initializes a new confidential secret id (never shared with P), then decides to share both the
+		// original and the confidential secret id with P in a single call.
+		val withConfidential = aApi.patient.initializeConfidentialSecretId(sharedWithP)
+		val confidentialSecretId = aApi.patient.getConfidentialSecretIdsOf(withConfidential).single()
+		val allSecretIds = setOf(originalSecretId, confidentialSecretId)
+
+		val resharedWithBoth = aApi.patient.shareWith(
+			p.dataOwnerId,
+			withConfidential,
+			PatientShareOptions(shareSecretIds = SecretIdShareOptions.UseExactly(allSecretIds, false))
+		)
+		resharedWithBoth.rev shouldNotBe withConfidential.rev
+		val aToPAfter = resharedWithBoth.securityMetadata.shouldNotBeNull().secureDelegations.values.single { it.delegate == p.dataOwnerId }
+		aToPAfter.secretIds shouldHaveSize 2
+		aApi.patient.getSecretIdsOf(resharedWithBoth).keys shouldBe allSecretIds
+	}
+
+	"sharing with a delegate that only needs the part of the content not already reachable through someone else creates a delegation containing just that part".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val p = createHcpUser()
+		val a = createHcpUser(p)
+		val b = createHcpUser(p)
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+		val pApi = p.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+
+		// Share only the secret id with P.
+		val sharedWithP = aApi.patient.shareWith(
+			p.dataOwnerId,
+			created,
+			PatientShareOptions(
+				shareEncryptionKey = ShareMetadataBehaviour.Never,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		// Share both the secret id and the encryption key with B.
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			sharedWithP,
+			PatientShareOptions(
+				shareEncryptionKey = ShareMetadataBehaviour.Required,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+
+		// B tries to share both the secret id and the encryption key with P: the secret id is already
+		// reachable by P through the existing A->P delegation (which B can decrypt via P's key), but the
+		// encryption key never was - the new B->P delegation only needs to carry the encryption key.
+		val bKnownSecretIds = bApi.patient.getSecretIdsOf(sharedWithB).keys
+		val resharedByB = bApi.patient.shareWith(
+			p.dataOwnerId,
+			sharedWithB,
+			PatientShareOptions(
+				shareEncryptionKey = ShareMetadataBehaviour.Required,
+				shareSecretIds = SecretIdShareOptions.UseExactly(bKnownSecretIds, false)
+			)
+		)
+		resharedByB.rev shouldNotBe sharedWithB.rev
+		val bToP = resharedByB.securityMetadata.shouldNotBeNull().secureDelegations.values
+			.single { it.delegate == p.dataOwnerId && it.delegator == b.dataOwnerId }
+		bToP.secretIds.shouldBeEmpty()
+		bToP.encryptionKeys shouldHaveSize 1
+		pApi.patient.getEncryptionKeysOf(resharedByB) shouldHaveSize 1
+	}
+})

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/SharingOptimizationTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/crypto/SharingOptimizationTest.kt
@@ -427,4 +427,100 @@ class SharingOptimizationTest : StringSpec({
 		bToP.encryptionKeys shouldHaveSize 1
 		pApi.patient.getEncryptionKeysOf(resharedByB) shouldHaveSize 1
 	}
+
+	"a MaxWrite request is a no-op if the current data owner can itself grant at most read access and the delegate already has read access".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val b = createHcpUser()
+		val x = createHcpUser()
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+
+		// A only gives B read-only access.
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			created,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		bApi.patient.hasWriteAccess(sharedWithB) shouldBe false
+
+		// B, who itself only has read access, shares the same content with X, also at read level.
+		val bKnownSecretIds = bApi.patient.getSecretIdsOf(sharedWithB).keys
+		val sharedWithX = bApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithB,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(bKnownSecretIds, false)
+			)
+		)
+
+		// B tries again, this time requesting MaxWrite: since B itself only has read access, MaxWrite
+		// (which caps the grant at whatever the current data owner already has) can only ever grant read
+		// too - and X already has read (from B's own earlier share), so there is genuinely nothing this
+		// could add. Unlike the earlier "higher requested permission" test, this is not an upgrade
+		// attempt at all, just a request that resolves to something already fully satisfied.
+		val resharedWithMaxWrite = bApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithX,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.MaxWrite,
+				shareSecretIds = SecretIdShareOptions.UseExactly(bKnownSecretIds, false)
+			)
+		)
+		resharedWithMaxWrite.rev shouldBe sharedWithX.rev
+	}
+
+	"sharing read access with a delegate that a parent's own delegation already gave the same read access to is a no-op".config(enabled = DEFAULT_ENABLED && LOCAL_ENV_ONLY) {
+		val a = createHcpUser()
+		val b = createHcpUser(a)
+		val x = createHcpUser()
+		val aApi = a.api(specJob)
+		val bApi = b.api(specJob)
+
+		val created = aApi.patient.createPatient(
+			aApi.patient.withEncryptionMetadata(DecryptedPatient(id = uuid(), firstName = "John", lastName = "Doe"))
+		)
+		val secretIds = aApi.patient.getSecretIdsOf(created).keys
+
+		// A shares read-only access with its own child B.
+		val sharedWithB = aApi.patient.shareWith(
+			b.dataOwnerId,
+			created,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+		// A also shares read-only access with X directly (A->X - B is not a party to this delegation).
+		val sharedWithX = aApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithB,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(secretIds, false)
+			)
+		)
+
+		// B (A's child, holding A's key) can decrypt the existing A->X delegation and see that X already
+		// has read access to this same content - so B's own attempt to share the same content with X, also
+		// at read level, is a no-op, even though B was never a party to A->X itself.
+		val bKnownSecretIds = bApi.patient.getSecretIdsOf(sharedWithX).keys
+		val resharedByB = bApi.patient.shareWith(
+			x.dataOwnerId,
+			sharedWithX,
+			PatientShareOptions(
+				requestedPermissions = RequestedPermission.FullRead,
+				shareSecretIds = SecretIdShareOptions.UseExactly(bKnownSecretIds, false)
+			)
+		)
+		resharedByB.rev shouldBe sharedWithX.rev
+	}
 })


### PR DESCRIPTION
New optimization to entity sharing methods avoids creation of redundant delegations when the current data owner can verify that all data is already available to the delegate